### PR TITLE
Allow path() to return dirs as was allowed in importlib_resources 1.0.

### DIFF
--- a/importlib_resources/_compat.py
+++ b/importlib_resources/_compat.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 # flake8: noqa
 
+import functools
+import warnings
+import contextlib
+
 try:
     from pathlib import Path, PurePath
 except ImportError:
@@ -30,6 +34,12 @@ except NameError:
 
 
 try:
+    IsADirectoryError = IsADirectoryError                       # type: ignore
+except NameError:
+    IsADirectoryError = OSError                                 # type: ignore
+
+
+try:
     from importlib import metadata
 except ImportError:
     import importlib_metadata as metadata  # type: ignore
@@ -52,3 +62,27 @@ def package_spec(package):
 			origin=package.__file__,
 			loader=getattr(package, '__loader__', None),
 		)
+
+
+def allow_dirs(orig):
+    """
+    In #85, this project learned of an unexpected feature that
+    would expose directories as resources. This function provides
+    temporary compatibility for that expectation.
+    """
+    @functools.wraps(orig)
+    @contextlib.contextmanager
+    def wrapper(package, resource):
+        try:
+            with orig(package, resource) as res:
+                yield res
+        except IsADirectoryError:
+            warnings.warn(
+                "Retrieving directories with path() is not supported. "
+                "Use files instead.",
+                DeprecationWarning,
+                )
+            from importlib_resources import files
+            yield files(package).joinpath(resource)
+
+    return wrapper

--- a/importlib_resources/_py2.py
+++ b/importlib_resources/_py2.py
@@ -2,6 +2,7 @@ import os
 import errno
 
 from . import trees
+from . import _compat
 from ._compat import FileNotFoundError
 from importlib import import_module
 from io import BytesIO, TextIOWrapper, open as io_open
@@ -97,6 +98,7 @@ def files(package):
     return trees.from_package(_get_package(package))
 
 
+@_compat.allow_dirs
 def path(package, resource):
     """A context manager providing a file path object to the resource.
 

--- a/importlib_resources/_py3.py
+++ b/importlib_resources/_py3.py
@@ -3,6 +3,7 @@ import sys
 
 from . import abc as resources_abc
 from . import trees
+from . import _compat
 from contextlib import contextmanager, suppress
 from importlib import import_module
 from importlib.abc import ResourceLoader
@@ -139,6 +140,7 @@ def files(package: Package) -> trees.Traversable:
     return trees.from_package(_get_package(package))
 
 
+@_compat.allow_dirs
 def path(
         package: Package, resource: Resource,
         ) -> 'ContextManager[Path]':

--- a/importlib_resources/tests/test_path.py
+++ b/importlib_resources/tests/test_path.py
@@ -4,6 +4,8 @@ import importlib_resources as resources
 from . import data01
 from . import util
 
+from .._compat import IsADirectoryError
+
 
 class CommonTests(util.CommonTests, unittest.TestCase):
 
@@ -24,9 +26,19 @@ class PathTests:
                 text = file.read()
             self.assertEqual('Hello, UTF-8 world!\n', text)
 
+    def test_dirs_not_allowed(self):
+        return  # expected to fail; ref #85
+        with self.assertRaises(IsADirectoryError):
+            resources.path(self.data, 'subdirectory')
+
 
 class PathDiskTests(PathTests, unittest.TestCase):
     data = data01
+
+    def test_dirs_allowed(self):
+        "temporarily allow dirs to be retrieved; ref #85"
+        with resources.path(self.data, 'subdirectory') as path:
+            assert path.is_dir()
 
 
 class PathZipTests(PathTests, util.ZipSetup, unittest.TestCase):

--- a/importlib_resources/tests/util.py
+++ b/importlib_resources/tests/util.py
@@ -167,6 +167,7 @@ class CommonTests(ABC):
         self.execute(package, 'utf-8.file')
         self.assertEqual(package.__loader__._path, 'utf-8.file')
 
+    @unittest.skipIf(sys.version_info < (3,), 'No ResourceReader in Python 2')
     def test_useless_loader(self):
         package = create_package(file=FileNotFoundError(),
                                  path=FileNotFoundError())


### PR DESCRIPTION
In GitLab by @jaraco on Mar 3, 2020, 05:14

Closes #85.