### PR TITLE
Implement a low-level interface for loaders to implement instead of TraversableResources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v5.1.0
+======
+
+* Added ``simple`` module implementing adapters from
+  a low-level resource reader interface to a
+  ``TraversableResources`` interface. Closes #90.
+
 v5.0.1
 ======
 

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -223,10 +223,7 @@ class ResourceContainer(Traversable):
         return False
 
     def iterdir(self):
-        files = (
-            ResourceHandle(self, name)
-            for name in self.reader.resources
-            )
+        files = (ResourceHandle(self, name) for name in self.reader.resources)
         dirs = map(ResourceContainer, self.reader.children())
         return itertools.chain(files, dirs)
 
@@ -235,9 +232,8 @@ class ResourceContainer(Traversable):
 
     def joinpath(self, name):
         return next(
-            traversable
-            for traversable in self.iterdir()
-            if traversable.name == name)
+            traversable for traversable in self.iterdir() if traversable.name == name
+        )
 
 
 class TraversableReader(TraversableResources, SimpleReader):
@@ -246,5 +242,6 @@ class TraversableReader(TraversableResources, SimpleReader):
     may derive from this class to provide the TraversableResources
     interface by supplying the SimpleReader interface.
     """
+
     def files(self):
         return ResourceContainer(self)

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -112,25 +112,25 @@ class Traversable(Protocol):
         """
 
 
-class ResourceReader:
+class SimpleReader:
     # Holds the string name of the virtual Python package this is a resource loader for.
     # For filesystems, this is effectively a reader for a directory at `fullname.replace('.', '/')`
     fullname = None
 
-    def child_readers(self) -> [ResourceReader]
+    def child_readers(self) -> ['SimpleReader']:
         """Obtain an iterable of ResourceReader for available child virtual packages of this one.
 
         On filesystems, this essentially returns instances corresponding to immediate child directories.
         """
 
-    def resources(self) -> [str]
+    def resources(self) -> [str]:
         """Obtain available named resources for this virtual package.
 
         On filesystems, this essentially returns files in the current directory.
         TODO consider returning a special type that exposes an `open()`, etc.
-        """"
+        """
 
-    def open_binary(self, resource) -> File
+    def open_binary(self, resource) -> BinaryIO:
         """Obtain a File-like for a named resource.
 
         On filesystems, this attempts to open os.path.join(self, resource).

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -189,7 +189,7 @@ class ResourceHandle(Traversable):
     def __init__(self, parent, name):
         # type: (ResourceContainer, str) -> None
         self.parent = parent
-        self.name = name
+        self.name = name  # type: ignore
 
     def is_file(self):
         return True

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,7 +1,5 @@
 import abc
-import io
-import itertools
-from typing import BinaryIO, Iterable, Text, List
+from typing import BinaryIO, Iterable, Text
 
 from ._compat import runtime_checkable, Protocol
 
@@ -116,46 +114,6 @@ class Traversable(Protocol):
         """
 
 
-class SimpleReader(abc.ABC):
-    """
-    The minimum, low-level interface required from a resource
-    provider.
-    """
-
-    @abc.abstractproperty
-    def package(self):
-        # type: () -> str
-        """
-        The name of the package for which this reader loads resources.
-        """
-
-    @abc.abstractmethod
-    def children(self):
-        # type: () -> List['SimpleReader']
-        """
-        Obtain an iterable of SimpleReader for available
-        child containers (e.g. directories).
-        """
-
-    @abc.abstractmethod
-    def resources(self):
-        # type: () -> List[str]
-        """
-        Obtain available named resources for this virtual package.
-        """
-
-    @abc.abstractmethod
-    def open_binary(self, resource):
-        # type: (str) -> BinaryIO
-        """
-        Obtain a File-like for a named resource.
-        """
-
-    @property
-    def name(self):
-        return self.package.split('.')[-1]
-
-
 class TraversableResources(ResourceReader):
     """
     The required interface for providing traversable
@@ -177,69 +135,3 @@ class TraversableResources(ResourceReader):
 
     def contents(self):
         return (item.name for item in self.files().iterdir())
-
-
-class ResourceHandle(Traversable):
-    """
-    Handle to a named resource in a ResourceReader.
-    """
-
-    def __init__(self, parent, name):
-        # type: (ResourceContainer, str) -> None
-        self.parent = parent
-        self.name = name  # type: ignore
-
-    def is_file(self):
-        return True
-
-    def is_dir(self):
-        return False
-
-    def open(self, mode='r', *args, **kwargs):
-        stream = self.parent.reader.open_binary(self.name)
-        if 'b' not in mode:
-            stream = io.TextIOWrapper(*args, **kwargs)
-        return stream
-
-    def joinpath(self, name):
-        raise RuntimeError("Cannot traverse into a resource")
-
-
-class ResourceContainer(Traversable):
-    """
-    Traversable container for a package's resources via its reader.
-    """
-
-    def __init__(self, reader):
-        # type: (SimpleReader) -> None
-        self.reader = reader
-
-    def is_dir(self):
-        return True
-
-    def is_file(self):
-        return False
-
-    def iterdir(self):
-        files = (ResourceHandle(self, name) for name in self.reader.resources)
-        dirs = map(ResourceContainer, self.reader.children())
-        return itertools.chain(files, dirs)
-
-    def open(self, *args, **kwargs):
-        raise IsADirectoryError()
-
-    def joinpath(self, name):
-        return next(
-            traversable for traversable in self.iterdir() if traversable.name == name
-        )
-
-
-class TraversableReader(TraversableResources, SimpleReader):
-    """
-    A TraversableResources based on SimpleReader. Resource providers
-    may derive from this class to provide the TraversableResources
-    interface by supplying the SimpleReader interface.
-    """
-
-    def files(self):
-        return ResourceContainer(self)

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -125,10 +125,10 @@ class SimpleReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def child_readers(self) -> List['SimpleReader']:
+    def children(self) -> List['SimpleReader']:
         """
-        Obtain an iterable of ResourceReader for available
-        child virtual packages of this one.
+        Obtain an iterable of SimpleReader for available
+        child containers (e.g. directories).
         """
 
     @abc.abstractmethod
@@ -210,7 +210,7 @@ class ResourceContainer(Traversable):
             ResourceHandle(self, name)
             for name in self.resources
             )
-        dirs = map(ResourceContainer, self.child_readers())
+        dirs = map(ResourceContainer, self.children())
         return itertools.chain(files, dirs)
 
     def open(self, *args, **kwargs):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -125,20 +125,23 @@ class SimpleReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def children(self) -> List['SimpleReader']:
+    def children(self):
+        # type: () -> List['SimpleReader']
         """
         Obtain an iterable of SimpleReader for available
         child containers (e.g. directories).
         """
 
     @abc.abstractmethod
-    def resources(self) -> List[str]:
+    def resources(self):
+        # type: () -> List[str]
         """
         Obtain available named resources for this virtual package.
         """
 
     @abc.abstractmethod
-    def open_binary(self, resource) -> BinaryIO:
+    def open_binary(self, resource):
+        # type: (str) -> BinaryIO
         """
         Obtain a File-like for a named resource.
         """
@@ -196,7 +199,8 @@ class ResourceContainer(Traversable):
     Traversable container for a package's resources via its reader.
     """
 
-    def __init__(self, reader: SimpleReader):
+    def __init__(self, reader):
+        # type: (SimpleReader) -> None
         self.reader = reader
 
     def is_dir(self):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,7 +1,7 @@
 import abc
 import io
 import itertools
-from typing import BinaryIO, Iterable, Text
+from typing import BinaryIO, Iterable, Text, List
 
 from ._compat import runtime_checkable, Protocol
 
@@ -125,14 +125,14 @@ class SimpleReader(abc.ABC):
         """
 
     @abc.abstractmethod
-    def child_readers(self) -> ['SimpleReader']:
+    def child_readers(self) -> List['SimpleReader']:
         """
         Obtain an iterable of ResourceReader for available
         child virtual packages of this one.
         """
 
     @abc.abstractmethod
-    def resources(self) -> [str]:
+    def resources(self) -> List[str]:
         """
         Obtain available named resources for this virtual package.
         """

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -112,31 +112,31 @@ class Traversable(Protocol):
         """
 
 
-class SimpleReader:
-    # Holds the string name of the virtual Python package this is a resource loader for.
-    # For filesystems, this is effectively a reader for a directory at `fullname.replace('.', '/')`
-    fullname = None
+class SimpleReader(ABC):
 
+    @abc.abstractproperty
+    def package(self):
+        """
+        The name of the package for which this reader loads resources.
+        """
+
+    @abc.abstractmethod
     def child_readers(self) -> ['SimpleReader']:
-        """Obtain an iterable of ResourceReader for available child virtual packages of this one.
-
-        On filesystems, this essentially returns instances corresponding to immediate child directories.
+        """
+        Obtain an iterable of ResourceReader for available
+        child virtual packages of this one.
         """
 
+    @abc.abstractmethod
     def resources(self) -> [str]:
-        """Obtain available named resources for this virtual package.
-
-        On filesystems, this essentially returns files in the current directory.
-        TODO consider returning a special type that exposes an `open()`, etc.
+        """
+        Obtain available named resources for this virtual package.
         """
 
+    @abc.abstractmethod
     def open_binary(self, resource) -> BinaryIO:
-        """Obtain a File-like for a named resource.
-
-        On filesystems, this attempts to open os.path.join(self, resource).
-
-        Attempting to open a non-resource entity (such as a subdirectory) or a missing
-        resource raises NotAResourceError.
+        """
+        Obtain a File-like for a named resource.
         """
 
 

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -61,17 +61,19 @@ class Traversable(Protocol):
         Yield Traversable objects in self
         """
 
-    @abc.abstractmethod
     def read_bytes(self):
         """
         Read contents of self as bytes
         """
+        with self.open('rb') as strm:
+            return strm.read()
 
-    @abc.abstractmethod
     def read_text(self, encoding=None):
         """
-        Read contents of self as bytes
+        Read contents of self as text
         """
+        with self.open(encoding=encoding) as strm:
+            return strm.read()
 
     @abc.abstractmethod
     def is_dir(self):
@@ -91,11 +93,11 @@ class Traversable(Protocol):
         Return Traversable child in self
         """
 
-    @abc.abstractmethod
     def __truediv__(self, child):
         """
         Return Traversable child in self
         """
+        return self.joinpath(child)
 
     @abc.abstractmethod
     def open(self, mode='r', *args, **kwargs):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -112,6 +112,34 @@ class Traversable(Protocol):
         """
 
 
+class ResourceReader:
+    # Holds the string name of the virtual Python package this is a resource loader for.
+    # For filesystems, this is effectively a reader for a directory at `fullname.replace('.', '/')`
+    fullname = None
+
+    def child_readers(self) -> [ResourceReader]
+        """Obtain an iterable of ResourceReader for available child virtual packages of this one.
+
+        On filesystems, this essentially returns instances corresponding to immediate child directories.
+        """
+
+    def resources(self) -> [str]
+        """Obtain available named resources for this virtual package.
+
+        On filesystems, this essentially returns files in the current directory.
+        TODO consider returning a special type that exposes an `open()`, etc.
+        """"
+
+    def open_binary(self, resource) -> File
+        """Obtain a File-like for a named resource.
+
+        On filesystems, this attempts to open os.path.join(self, resource).
+
+        Attempting to open a non-resource entity (such as a subdirectory) or a missing
+        resource raises NotAResourceError.
+        """
+
+
 class TraversableResources(ResourceReader):
     @abc.abstractmethod
     def files(self):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -167,6 +167,10 @@ class TraversableResources(ResourceReader):
 
 
 class ResourceHandle(Traversable):
+    """
+    Handle to a named resource in a ResourceReader.
+    """
+
     def __init__(self, reader, name):
         self.reader = reader
         self.name = name
@@ -183,8 +187,15 @@ class ResourceHandle(Traversable):
             stream = io.TextIOWrapper(*args, **kwargs)
         return stream
 
+    def joinpath(self, name):
+        raise RuntimeError("Cannot traverse into a resource")
+
 
 class ResourceContainer(Traversable):
+    """
+    Traversable container for a package's resources via its reader.
+    """
+
     def __init__(self, reader: SimpleReader):
         self.reader = reader
 

--- a/importlib_resources/simple.py
+++ b/importlib_resources/simple.py
@@ -1,0 +1,116 @@
+"""
+Interface adapters for low-level readers.
+"""
+
+import abc
+import io
+import itertools
+from typing import BinaryIO, List
+
+from .abc import Traversable, TraversableResources
+
+
+class SimpleReader(abc.ABC):
+    """
+    The minimum, low-level interface required from a resource
+    provider.
+    """
+
+    @abc.abstractproperty
+    def package(self):
+        # type: () -> str
+        """
+        The name of the package for which this reader loads resources.
+        """
+
+    @abc.abstractmethod
+    def children(self):
+        # type: () -> List['SimpleReader']
+        """
+        Obtain an iterable of SimpleReader for available
+        child containers (e.g. directories).
+        """
+
+    @abc.abstractmethod
+    def resources(self):
+        # type: () -> List[str]
+        """
+        Obtain available named resources for this virtual package.
+        """
+
+    @abc.abstractmethod
+    def open_binary(self, resource):
+        # type: (str) -> BinaryIO
+        """
+        Obtain a File-like for a named resource.
+        """
+
+    @property
+    def name(self):
+        return self.package.split('.')[-1]
+
+
+class ResourceHandle(Traversable):
+    """
+    Handle to a named resource in a ResourceReader.
+    """
+
+    def __init__(self, parent, name):
+        # type: (ResourceContainer, str) -> None
+        self.parent = parent
+        self.name = name  # type: ignore
+
+    def is_file(self):
+        return True
+
+    def is_dir(self):
+        return False
+
+    def open(self, mode='r', *args, **kwargs):
+        stream = self.parent.reader.open_binary(self.name)
+        if 'b' not in mode:
+            stream = io.TextIOWrapper(*args, **kwargs)
+        return stream
+
+    def joinpath(self, name):
+        raise RuntimeError("Cannot traverse into a resource")
+
+
+class ResourceContainer(Traversable):
+    """
+    Traversable container for a package's resources via its reader.
+    """
+
+    def __init__(self, reader):
+        # type: (SimpleReader) -> None
+        self.reader = reader
+
+    def is_dir(self):
+        return True
+
+    def is_file(self):
+        return False
+
+    def iterdir(self):
+        files = (ResourceHandle(self, name) for name in self.reader.resources)
+        dirs = map(ResourceContainer, self.reader.children())
+        return itertools.chain(files, dirs)
+
+    def open(self, *args, **kwargs):
+        raise IsADirectoryError()
+
+    def joinpath(self, name):
+        return next(
+            traversable for traversable in self.iterdir() if traversable.name == name
+        )
+
+
+class TraversableReader(TraversableResources, SimpleReader):
+    """
+    A TraversableResources based on SimpleReader. Resource providers
+    may derive from this class to provide the TraversableResources
+    interface by supplying the SimpleReader interface.
+    """
+
+    def files(self):
+        return ResourceContainer(self)


### PR DESCRIPTION
In GitLab by @jaraco on Mar 24, 2020, 11:36

As discussed in #90, this MR attempts to implemented the proposed interface for loaders to supply more basic functionality for loading resources.