### PR TITLE
Implement MultiplexedPath.iterdir using 'unique_everseen'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
+	*/_itertools.py
 
 [report]
 show_missing = True

--- a/importlib_resources/_itertools.py
+++ b/importlib_resources/_itertools.py
@@ -1,0 +1,19 @@
+from itertools import filterfalse
+
+
+def unique_everseen(iterable, key=None):
+    "List unique elements, preserving order. Remember all elements ever seen."
+    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
+    # unique_everseen('ABBCcAD', str.lower) --> A B C D
+    seen = set()
+    seen_add = seen.add
+    if key is None:
+        for element in filterfalse(seen.__contains__, iterable):
+            seen_add(element)
+            yield element
+    else:
+        for element in iterable:
+            k = key(element)
+            if k not in seen:
+                seen_add(k)
+                yield element

--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -1,8 +1,10 @@
 import collections
 import pathlib
+import operator
 
 from . import abc
 
+from ._itertools import unique_everseen
 from ._compat import ZipPath
 
 
@@ -65,13 +67,8 @@ class MultiplexedPath(abc.Traversable):
             raise NotADirectoryError('MultiplexedPath only supports directories')
 
     def iterdir(self):
-        visited = []
-        for path in self._paths:
-            for file in path.iterdir():
-                if file.name in visited:
-                    continue
-                visited.append(file.name)
-                yield file
+        files = (file for path in self._paths for file in path.iterdir())
+        return unique_everseen(files, key=operator.attrgetter('name'))
 
     def read_bytes(self):
         raise FileNotFoundError(f'{self} is not a file')


### PR DESCRIPTION
By building on `unique_everseen` this approach re-uses a well-known and tested pattern for filtering out duplicate items.