### PR TITLE
compat: fix zip traversables raise KeyError instead of FileNotFoundError on open

### DIFF
--- a/importlib_resources/_compat.py
+++ b/importlib_resources/_compat.py
@@ -5,9 +5,9 @@ import sys
 import pathlib
 from contextlib import suppress
 
-try:
+if sys.version_info >= (3, 10):
     from zipfile import Path as ZipPath  # type: ignore
-except ImportError:
+else:
     from zipp import Path as ZipPath  # type: ignore
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages = find_namespace:
 include_package_data = true
 python_requires = >=3.6
 install_requires =
-    zipp >= 0.4; python_version < '3.8'
+    zipp >= 3.1.0; python_version < '3.10'
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]


### PR DESCRIPTION
The fix[1] is available on zipp 3.1.0 and/or Python 3.10.

[1] https://github.com/jaraco/zipp/commit/ffee5684095af4324bf11d7cba8b2a51b29d6d9c

Signed-off-by: Filipe Laíns <lains@riseup.net>