### PR TITLE
docs/migration: explicitly set binary mode for open()

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -91,7 +91,7 @@ bytes.  E.g.::
 The equivalent code in ``importlib_resources`` is pretty straightforward::
 
     ref = importlib_resources.files('my.package').joinpath('resource.dat')
-    with ref.open() as fp:
+    with ref.open('rb') as fp:
         my_bytes = fp.read()
 
 


### PR DESCRIPTION
open() uses non-binary by default.  The equivalent pkg_resources.resource_stream() method opens in binary mode.

https://github.com/python/importlib_resources/blob/main/importlib_resources/abc.py#L101