### PR TITLE
_common: make as_file return the real file on os.PathLike

### DIFF
--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -109,8 +109,17 @@ def as_file(path):
 
 @as_file.register(pathlib.Path)
 @contextlib.contextmanager
-def _(path):
+def _as_file_pathlib(path):
     """
     Degenerate behavior for pathlib.Path objects.
     """
     yield path
+
+
+@as_file.register(os.PathLike)
+@contextlib.contextmanager
+def _as_file_pathlike(path):
+    """
+    Degenerate behavior for os.PathLike objects.
+    """
+    yield pathlib.Path(os.fspath(path))


### PR DESCRIPTION
We currently only have custom handling for pathlib.Path, but that means
that custom readers that do not using pathlib.Path will have their
traversables copied to a temporary directory in as_file, which can be an
expensive operation.
By adding a dispatch for os.PathLike, we extend this behavior for all
path-like objects.

Signed-off-by: Filipe Laíns <lains@riseup.net>