### PR TITLE
Avoid file descriptor refleaks in as_file.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v5.2.2
+======
+
+* #234: Fix refleak in ``as_file`` caught by CPython tests.
+
 v5.2.1
 ======
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -87,14 +87,16 @@ def _tempfile(reader, suffix=''):
     # properly.
     fd, raw_path = tempfile.mkstemp(suffix=suffix)
     try:
-        os.write(fd, reader())
-        os.close(fd)
+        try:
+            os.write(fd, reader())
+        finally:
+            os.close(fd)
         del reader
         yield pathlib.Path(raw_path)
     finally:
         try:
             os.remove(raw_path)
-        except (FileNotFoundError, PermissionError):
+        except FileNotFoundError:
             pass
 
 


### PR DESCRIPTION
As reported in https://github.com/python/cpython/pull/27436#issuecomment-890055350, merging the latest importlib_resources into CPython revealed a refleak. It appears the refleak has long been a part of the implementation but was previously uncovered by the tests. This change fixes that refleak.