### PR TITLE
abc: avoid abbreviations in the Traversable documentation

### DIFF
--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -76,7 +76,7 @@ class Traversable(Protocol):
     @abc.abstractmethod
     def is_dir(self) -> bool:
         """
-        Return True if self is a dir
+        Return True if self is a directory
         """
 
     @abc.abstractmethod


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>