### PR TITLE
Replace tests of legacy API with comparable tests of traversable API.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ omit =
 	# leading `*/` for pytest-dev/pytest-cov#456
 	*/.tox/*
 	*/_itertools.py
+	*/_legacy.py
 
 [report]
 show_missing = True

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v5.4.0
+======
+
+* *80: Test suite now relies entirely on the traversable
+  API.
+
 v5.3.0
 ======
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -6,7 +6,7 @@ import contextlib
 import types
 import importlib
 
-from typing import Union, Any, Optional
+from typing import Union, Optional
 from .abc import ResourceReader, Traversable
 
 from ._compat import wrap_spec
@@ -21,19 +21,6 @@ def files(package):
     Get a Traversable resource from a package
     """
     return from_package(get_package(package))
-
-
-def normalize_path(path):
-    # type: (Any) -> str
-    """Normalize a path by ensuring it is a string.
-
-    If the resulting string contains path separators, an exception is raised.
-    """
-    str_path = str(path)
-    parent, file_name = os.path.split(str_path)
-    if parent:
-        raise ValueError(f'{path!r} must be only a file name')
-    return file_name
 
 
 def get_resource_reader(package):

--- a/importlib_resources/_legacy.py
+++ b/importlib_resources/_legacy.py
@@ -4,7 +4,7 @@ import pathlib
 import types
 import warnings
 
-from typing import Union, Iterable, ContextManager, BinaryIO, TextIO
+from typing import Union, Iterable, ContextManager, BinaryIO, TextIO, Any
 
 from . import _common
 
@@ -27,16 +27,29 @@ def deprecated(func):
     return wrapper
 
 
+def normalize_path(path):
+    # type: (Any) -> str
+    """Normalize a path by ensuring it is a string.
+
+    If the resulting string contains path separators, an exception is raised.
+    """
+    str_path = str(path)
+    parent, file_name = os.path.split(str_path)
+    if parent:
+        raise ValueError(f'{path!r} must be only a file name')
+    return file_name
+
+
 @deprecated
 def open_binary(package: Package, resource: Resource) -> BinaryIO:
     """Return a file-like object opened for binary reading of the resource."""
-    return (_common.files(package) / _common.normalize_path(resource)).open('rb')
+    return (_common.files(package) / normalize_path(resource)).open('rb')
 
 
 @deprecated
 def read_binary(package: Package, resource: Resource) -> bytes:
     """Return the binary contents of the resource."""
-    return (_common.files(package) / _common.normalize_path(resource)).read_bytes()
+    return (_common.files(package) / normalize_path(resource)).read_bytes()
 
 
 @deprecated
@@ -47,7 +60,7 @@ def open_text(
     errors: str = 'strict',
 ) -> TextIO:
     """Return a file-like object opened for text reading of the resource."""
-    return (_common.files(package) / _common.normalize_path(resource)).open(
+    return (_common.files(package) / normalize_path(resource)).open(
         'r', encoding=encoding, errors=errors
     )
 
@@ -85,7 +98,7 @@ def is_resource(package: Package, name: str) -> bool:
 
     Directories are *not* resources.
     """
-    resource = _common.normalize_path(name)
+    resource = normalize_path(name)
     return any(
         traversable.name == resource and traversable.is_file()
         for traversable in _common.files(package).iterdir()
@@ -105,4 +118,4 @@ def path(
     raised if the file was deleted prior to the context manager
     exiting).
     """
-    return _common.as_file(_common.files(package) / _common.normalize_path(resource))
+    return _common.as_file(_common.files(package) / normalize_path(resource))

--- a/importlib_resources/tests/test_contents.py
+++ b/importlib_resources/tests/test_contents.py
@@ -15,8 +15,8 @@ class ContentsTests:
     }
 
     def test_contents(self):
-        with util.suppress_known_deprecation():
-            assert self.expected <= set(resources.contents(self.data))
+        contents = {path.name for path in resources.files(self.data).iterdir()}
+        assert self.expected <= contents
 
 
 class ContentsDiskTests(ContentsTests, unittest.TestCase):

--- a/importlib_resources/tests/test_open.py
+++ b/importlib_resources/tests/test_open.py
@@ -7,47 +7,44 @@ from . import util
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
     def execute(self, package, path):
-        with util.suppress_known_deprecation():
-            with resources.open_binary(package, path):
-                pass
+        target = resources.files(package).joinpath(path)
+        with target.open('rb'):
+            pass
 
 
 class CommonTextTests(util.CommonTests, unittest.TestCase):
     def execute(self, package, path):
-        with util.suppress_known_deprecation():
-            with resources.open_text(package, path):
-                pass
+        target = resources.files(package).joinpath(path)
+        with target.open():
+            pass
 
 
 class OpenTests:
     def test_open_binary(self):
-        with util.suppress_known_deprecation():
-            with resources.open_binary(self.data, 'binary.file') as fp:
-                result = fp.read()
-                self.assertEqual(result, b'\x00\x01\x02\x03')
+        target = resources.files(self.data) / 'binary.file'
+        with target.open('rb') as fp:
+            result = fp.read()
+            self.assertEqual(result, b'\x00\x01\x02\x03')
 
     def test_open_text_default_encoding(self):
-        with util.suppress_known_deprecation():
-            with resources.open_text(self.data, 'utf-8.file') as fp:
-                result = fp.read()
+        target = resources.files(self.data) / 'utf-8.file'
+        with target.open() as fp:
+            result = fp.read()
             self.assertEqual(result, 'Hello, UTF-8 world!\n')
 
     def test_open_text_given_encoding(self):
-        with util.suppress_known_deprecation():
-            with resources.open_text(
-                self.data, 'utf-16.file', 'utf-16', 'strict'
-            ) as fp:
-                result = fp.read()
+        target = resources.files(self.data) / 'utf-16.file'
+        with target.open(encoding='utf-16', errors='strict') as fp:
+            result = fp.read()
         self.assertEqual(result, 'Hello, UTF-16 world!\n')
 
     def test_open_text_with_errors(self):
         # Raises UnicodeError without the 'errors' argument.
-        with util.suppress_known_deprecation():
-            with resources.open_text(self.data, 'utf-16.file', 'utf-8', 'strict') as fp:
-                self.assertRaises(UnicodeError, fp.read)
-        with util.suppress_known_deprecation():
-            with resources.open_text(self.data, 'utf-16.file', 'utf-8', 'ignore') as fp:
-                result = fp.read()
+        target = resources.files(self.data) / 'utf-16.file'
+        with target.open(encoding='utf-8', errors='strict') as fp:
+            self.assertRaises(UnicodeError, fp.read)
+        with target.open(encoding='utf-8', errors='ignore') as fp:
+            result = fp.read()
         self.assertEqual(
             result,
             'H\x00e\x00l\x00l\x00o\x00,\x00 '
@@ -56,16 +53,12 @@ class OpenTests:
         )
 
     def test_open_binary_FileNotFoundError(self):
-        with util.suppress_known_deprecation():
-            self.assertRaises(
-                FileNotFoundError, resources.open_binary, self.data, 'does-not-exist'
-            )
+        target = resources.files(self.data) / 'does-not-exist'
+        self.assertRaises(FileNotFoundError, target.open, 'rb')
 
     def test_open_text_FileNotFoundError(self):
-        with util.suppress_known_deprecation():
-            self.assertRaises(
-                FileNotFoundError, resources.open_text, self.data, 'does-not-exist'
-            )
+        target = resources.files(self.data) / 'does-not-exist'
+        self.assertRaises(FileNotFoundError, target.open)
 
 
 class OpenDiskTests(OpenTests, unittest.TestCase):

--- a/importlib_resources/tests/test_path.py
+++ b/importlib_resources/tests/test_path.py
@@ -8,9 +8,8 @@ from . import util
 
 class CommonTests(util.CommonTests, unittest.TestCase):
     def execute(self, package, path):
-        with util.suppress_known_deprecation():
-            with resources.path(package, path):
-                pass
+        with resources.as_file(resources.files(package).joinpath(path)):
+            pass
 
 
 class PathTests:
@@ -18,13 +17,13 @@ class PathTests:
         # Path should be readable.
         # Test also implicitly verifies the returned object is a pathlib.Path
         # instance.
-        with util.suppress_known_deprecation():
-            with resources.path(self.data, 'utf-8.file') as path:
-                self.assertTrue(path.name.endswith("utf-8.file"), repr(path))
-                # pathlib.Path.read_text() was introduced in Python 3.5.
-                with path.open('r', encoding='utf-8') as file:
-                    text = file.read()
-                self.assertEqual('Hello, UTF-8 world!\n', text)
+        target = resources.files(self.data) / 'utf-8.file'
+        with resources.as_file(target) as path:
+            self.assertTrue(path.name.endswith("utf-8.file"), repr(path))
+            # pathlib.Path.read_text() was introduced in Python 3.5.
+            with path.open('r', encoding='utf-8') as file:
+                text = file.read()
+            self.assertEqual('Hello, UTF-8 world!\n', text)
 
 
 class PathDiskTests(PathTests, unittest.TestCase):
@@ -36,9 +35,9 @@ class PathDiskTests(PathTests, unittest.TestCase):
         file-system-backed resources do not get the tempdir
         treatment.
         """
-        with util.suppress_known_deprecation():
-            with resources.path(self.data, 'utf-8.file') as path:
-                assert 'data' in str(path)
+        target = resources.files(self.data) / 'utf-8.file'
+        with resources.as_file(target) as path:
+            assert 'data' in str(path)
 
 
 class PathMemoryTests(PathTests, unittest.TestCase):
@@ -56,9 +55,9 @@ class PathZipTests(PathTests, util.ZipSetup, unittest.TestCase):
     def test_remove_in_context_manager(self):
         # It is not an error if the file that was temporarily stashed on the
         # file system is removed inside the `with` stanza.
-        with util.suppress_known_deprecation():
-            with resources.path(self.data, 'utf-8.file') as path:
-                path.unlink()
+        target = resources.files(self.data) / 'utf-8.file'
+        with resources.as_file(target) as path:
+            path.unlink()
 
 
 if __name__ == '__main__':

--- a/importlib_resources/tests/test_read.py
+++ b/importlib_resources/tests/test_read.py
@@ -8,40 +8,36 @@ from importlib import import_module
 
 class CommonBinaryTests(util.CommonTests, unittest.TestCase):
     def execute(self, package, path):
-        with util.suppress_known_deprecation():
-            resources.read_binary(package, path)
+        resources.files(package).joinpath(path).read_bytes()
 
 
 class CommonTextTests(util.CommonTests, unittest.TestCase):
     def execute(self, package, path):
-        with util.suppress_known_deprecation():
-            resources.read_text(package, path)
+        resources.files(package).joinpath(path).read_text()
 
 
 class ReadTests:
-    def test_read_binary(self):
-        with util.suppress_known_deprecation():
-            result = resources.read_binary(self.data, 'binary.file')
+    def test_read_bytes(self):
+        result = resources.files(self.data).joinpath('binary.file').read_bytes()
         self.assertEqual(result, b'\0\1\2\3')
 
     def test_read_text_default_encoding(self):
-        with util.suppress_known_deprecation():
-            result = resources.read_text(self.data, 'utf-8.file')
+        result = resources.files(self.data).joinpath('utf-8.file').read_text()
         self.assertEqual(result, 'Hello, UTF-8 world!\n')
 
     def test_read_text_given_encoding(self):
-        with util.suppress_known_deprecation():
-            result = resources.read_text(self.data, 'utf-16.file', encoding='utf-16')
+        result = (
+            resources.files(self.data)
+            .joinpath('utf-16.file')
+            .read_text(encoding='utf-16')
+        )
         self.assertEqual(result, 'Hello, UTF-16 world!\n')
 
     def test_read_text_with_errors(self):
         # Raises UnicodeError without the 'errors' argument.
-        with util.suppress_known_deprecation():
-            self.assertRaises(
-                UnicodeError, resources.read_text, self.data, 'utf-16.file'
-            )
-        with util.suppress_known_deprecation():
-            result = resources.read_text(self.data, 'utf-16.file', errors='ignore')
+        target = resources.files(self.data) / 'utf-16.file'
+        self.assertRaises(UnicodeError, target.read_text, encoding='utf-8')
+        result = target.read_text(encoding='utf-8', errors='ignore')
         self.assertEqual(
             result,
             'H\x00e\x00l\x00l\x00o\x00,\x00 '
@@ -57,13 +53,15 @@ class ReadDiskTests(ReadTests, unittest.TestCase):
 class ReadZipTests(ReadTests, util.ZipSetup, unittest.TestCase):
     def test_read_submodule_resource(self):
         submodule = import_module('ziptestdata.subdirectory')
-        with util.suppress_known_deprecation():
-            result = resources.read_binary(submodule, 'binary.file')
+        result = resources.files(submodule).joinpath('binary.file').read_bytes()
         self.assertEqual(result, b'\0\1\2\3')
 
     def test_read_submodule_resource_by_name(self):
-        with util.suppress_known_deprecation():
-            result = resources.read_binary('ziptestdata.subdirectory', 'binary.file')
+        result = (
+            resources.files('ziptestdata.subdirectory')
+            .joinpath('binary.file')
+            .read_bytes()
+        )
         self.assertEqual(result, b'\0\1\2\3')
 
 

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -14,38 +14,18 @@ from ._compat import import_helper, unlink
 class ResourceTests:
     # Subclasses are expected to set the `data` attribute.
 
-    def test_is_resource_good_path(self):
-        with util.suppress_known_deprecation():
-            self.assertTrue(resources.is_resource(self.data, 'binary.file'))
+    def test_is_file_exists(self):
+        target = resources.files(self.data) / 'binary.file'
+        self.assertTrue(target.is_file())
 
-    def test_is_resource_missing(self):
-        with util.suppress_known_deprecation():
-            self.assertFalse(resources.is_resource(self.data, 'not-a-file'))
+    def test_is_file_missing(self):
+        target = resources.files(self.data) / 'not-a-file'
+        self.assertFalse(target.is_file())
 
-    def test_is_resource_subresource_directory(self):
-        # Directories are not resources.
-        with util.suppress_known_deprecation():
-            self.assertFalse(resources.is_resource(self.data, 'subdirectory'))
-
-    def test_contents(self):
-        with util.suppress_known_deprecation():
-            contents = set(resources.contents(self.data))
-        # There may be cruft in the directory listing of the data directory.
-        # It could have a __pycache__ directory,
-        # an artifact of the
-        # test suite importing these modules, which
-        # are not germane to this test, so just filter them out.
-        contents.discard('__pycache__')
-        self.assertEqual(
-            sorted(contents),
-            [
-                '__init__.py',
-                'binary.file',
-                'subdirectory',
-                'utf-16.file',
-                'utf-8.file',
-            ],
-        )
+    def test_is_dir(self):
+        target = resources.files(self.data) / 'subdirectory'
+        self.assertFalse(target.is_file())
+        self.assertTrue(target.is_dir())
 
 
 class ResourceDiskTests(ResourceTests, unittest.TestCase):
@@ -57,34 +37,34 @@ class ResourceZipTests(ResourceTests, util.ZipSetup, unittest.TestCase):
     pass
 
 
+def names(traversable):
+    return {item.name for item in traversable.iterdir()}
+
+
 class ResourceLoaderTests(unittest.TestCase):
     def test_resource_contents(self):
         package = util.create_package(
             file=data01, path=data01.__file__, contents=['A', 'B', 'C']
         )
-        with util.suppress_known_deprecation():
-            self.assertEqual(set(resources.contents(package)), {'A', 'B', 'C'})
+        self.assertEqual(names(resources.files(package)), {'A', 'B', 'C'})
 
-    def test_resource_is_resource(self):
+    def test_is_file(self):
         package = util.create_package(
             file=data01, path=data01.__file__, contents=['A', 'B', 'C', 'D/E', 'D/F']
         )
-        with util.suppress_known_deprecation():
-            self.assertTrue(resources.is_resource(package, 'B'))
+        self.assertTrue(resources.files(package).joinpath('B').is_file())
 
-    def test_resource_directory_is_not_resource(self):
+    def test_is_dir(self):
         package = util.create_package(
             file=data01, path=data01.__file__, contents=['A', 'B', 'C', 'D/E', 'D/F']
         )
-        with util.suppress_known_deprecation():
-            self.assertFalse(resources.is_resource(package, 'D'))
+        self.assertTrue(resources.files(package).joinpath('D').is_dir())
 
-    def test_resource_missing_is_not_resource(self):
+    def test_resource_missing(self):
         package = util.create_package(
             file=data01, path=data01.__file__, contents=['A', 'B', 'C', 'D/E', 'D/F']
         )
-        with util.suppress_known_deprecation():
-            self.assertFalse(resources.is_resource(package, 'Z'))
+        self.assertFalse(resources.files(package).joinpath('Z').is_file())
 
 
 class ResourceCornerCaseTests(unittest.TestCase):
@@ -102,8 +82,7 @@ class ResourceCornerCaseTests(unittest.TestCase):
         module.__file__ = '/path/which/shall/not/be/named'
         module.__spec__.loader = module.__loader__
         module.__spec__.origin = module.__file__
-        with util.suppress_known_deprecation():
-            self.assertFalse(resources.is_resource(module, 'A'))
+        self.assertFalse(resources.files(module).joinpath('A').is_file())
 
 
 class ResourceFromZipsTest01(util.ZipSetupBase, unittest.TestCase):
@@ -111,28 +90,26 @@ class ResourceFromZipsTest01(util.ZipSetupBase, unittest.TestCase):
 
     def test_is_submodule_resource(self):
         submodule = import_module('ziptestdata.subdirectory')
-        with util.suppress_known_deprecation():
-            self.assertTrue(resources.is_resource(submodule, 'binary.file'))
+        self.assertTrue(resources.files(submodule).joinpath('binary.file').is_file())
 
     def test_read_submodule_resource_by_name(self):
-        with util.suppress_known_deprecation():
-            self.assertTrue(
-                resources.is_resource('ziptestdata.subdirectory', 'binary.file')
-            )
+        self.assertTrue(
+            resources.files('ziptestdata.subdirectory')
+            .joinpath('binary.file')
+            .is_file()
+        )
 
     def test_submodule_contents(self):
         submodule = import_module('ziptestdata.subdirectory')
-        with util.suppress_known_deprecation():
-            self.assertEqual(
-                set(resources.contents(submodule)), {'__init__.py', 'binary.file'}
-            )
+        self.assertEqual(
+            names(resources.files(submodule)), {'__init__.py', 'binary.file'}
+        )
 
     def test_submodule_contents_by_name(self):
-        with util.suppress_known_deprecation():
-            self.assertEqual(
-                set(resources.contents('ziptestdata.subdirectory')),
-                {'__init__.py', 'binary.file'},
-            )
+        self.assertEqual(
+            names(resources.files('ziptestdata.subdirectory')),
+            {'__init__.py', 'binary.file'},
+        )
 
 
 class ResourceFromZipsTest02(util.ZipSetupBase, unittest.TestCase):
@@ -143,16 +120,14 @@ class ResourceFromZipsTest02(util.ZipSetupBase, unittest.TestCase):
         Test thata zip with two unrelated subpackages return
         distinct resources. Ref python/importlib_resources#44.
         """
-        with util.suppress_known_deprecation():
-            self.assertEqual(
-                set(resources.contents('ziptestdata.one')),
-                {'__init__.py', 'resource1.txt'},
-            )
-        with util.suppress_known_deprecation():
-            self.assertEqual(
-                set(resources.contents('ziptestdata.two')),
-                {'__init__.py', 'resource2.txt'},
-            )
+        self.assertEqual(
+            names(resources.files('ziptestdata.one')),
+            {'__init__.py', 'resource1.txt'},
+        )
+        self.assertEqual(
+            names(resources.files('ziptestdata.two')),
+            {'__init__.py', 'resource2.txt'},
+        )
 
 
 class DeletingZipsTest(unittest.TestCase):
@@ -192,47 +167,43 @@ class DeletingZipsTest(unittest.TestCase):
             # If the test fails, this will probably fail too
             pass
 
-    def test_contents_does_not_keep_open(self):
-        with util.suppress_known_deprecation():
-            c = resources.contents('ziptestdata')
+    def test_iterdir_does_not_keep_open(self):
+        c = [item.name for item in resources.files('ziptestdata').iterdir()]
         self.zip_path.unlink()
         del c
 
-    def test_is_resource_does_not_keep_open(self):
-        with util.suppress_known_deprecation():
-            c = resources.is_resource('ziptestdata', 'binary.file')
+    def test_is_file_does_not_keep_open(self):
+        c = resources.files('ziptestdata').joinpath('binary.file').is_file()
         self.zip_path.unlink()
         del c
 
-    def test_is_resource_failure_does_not_keep_open(self):
-        with util.suppress_known_deprecation():
-            c = resources.is_resource('ziptestdata', 'not-present')
+    def test_is_file_failure_does_not_keep_open(self):
+        c = resources.files('ziptestdata').joinpath('not-present').is_file()
         self.zip_path.unlink()
         del c
 
     @unittest.skip("Desired but not supported.")
-    def test_path_does_not_keep_open(self):
-        c = resources.path('ziptestdata', 'binary.file')
+    def test_as_file_does_not_keep_open(self):  # pragma: no cover
+        c = resources.as_file(resources.files('ziptestdata') / 'binary.file')
         self.zip_path.unlink()
         del c
 
     def test_entered_path_does_not_keep_open(self):
         # This is what certifi does on import to make its bundle
         # available for the process duration.
-        with util.suppress_known_deprecation():
-            c = resources.path('ziptestdata', 'binary.file').__enter__()
+        c = resources.as_file(
+            resources.files('ziptestdata') / 'binary.file'
+        ).__enter__()
         self.zip_path.unlink()
         del c
 
     def test_read_binary_does_not_keep_open(self):
-        with util.suppress_known_deprecation():
-            c = resources.read_binary('ziptestdata', 'binary.file')
+        c = resources.files('ziptestdata').joinpath('binary.file').read_bytes()
         self.zip_path.unlink()
         del c
 
     def test_read_text_does_not_keep_open(self):
-        with util.suppress_known_deprecation():
-            c = resources.read_text('ziptestdata', 'utf-8.file', encoding='utf-8')
+        c = resources.files('ziptestdata').joinpath('utf-8.file').read_text()
         self.zip_path.unlink()
         del c
 
@@ -249,18 +220,19 @@ class ResourceFromNamespaceTest01(unittest.TestCase):
         sys.path.remove(cls.site_dir)
 
     def test_is_submodule_resource(self):
-        with util.suppress_known_deprecation():
-            self.assertTrue(
-                resources.is_resource(import_module('namespacedata01'), 'binary.file')
-            )
+        self.assertTrue(
+            resources.files(import_module('namespacedata01'))
+            .joinpath('binary.file')
+            .is_file()
+        )
 
     def test_read_submodule_resource_by_name(self):
-        with util.suppress_known_deprecation():
-            self.assertTrue(resources.is_resource('namespacedata01', 'binary.file'))
+        self.assertTrue(
+            resources.files('namespacedata01').joinpath('binary.file').is_file()
+        )
 
     def test_submodule_contents(self):
-        with util.suppress_known_deprecation():
-            contents = set(resources.contents(import_module('namespacedata01')))
+        contents = names(resources.files(import_module('namespacedata01')))
         try:
             contents.remove('__pycache__')
         except KeyError:
@@ -268,8 +240,7 @@ class ResourceFromNamespaceTest01(unittest.TestCase):
         self.assertEqual(contents, {'binary.file', 'utf-8.file', 'utf-16.file'})
 
     def test_submodule_contents_by_name(self):
-        with util.suppress_known_deprecation():
-            contents = set(resources.contents('namespacedata01'))
+        contents = names(resources.files('namespacedata01'))
         try:
             contents.remove('__pycache__')
         except KeyError:

--- a/importlib_resources/tests/util.py
+++ b/importlib_resources/tests/util.py
@@ -1,10 +1,8 @@
 import abc
-import contextlib
 import importlib
 import io
 import sys
 import types
-import warnings
 from pathlib import Path, PurePath
 
 from . import data01
@@ -67,13 +65,6 @@ def create_package(file=None, path=None, is_package=True, contents=()):
         Reader(file=file, path=path, _contents=contents),
         is_package,
     )
-
-
-@contextlib.contextmanager
-def suppress_known_deprecation():
-    with warnings.catch_warnings(record=True) as ctx:
-        warnings.simplefilter('default', category=DeprecationWarning)
-        yield ctx
 
 
 class CommonTests(metaclass=abc.ABCMeta):

--- a/importlib_resources/tests/util.py
+++ b/importlib_resources/tests/util.py
@@ -106,18 +106,6 @@ class CommonTests(metaclass=abc.ABCMeta):
         path = PurePath('utf-8.file')
         self.execute(data01, path)
 
-    def test_absolute_path(self):
-        # An absolute path is a ValueError.
-        path = Path(__file__)
-        full_path = path.parent / 'utf-8.file'
-        with self.assertRaises(ValueError):
-            self.execute(data01, full_path)
-
-    def test_relative_path(self):
-        # A reative path is a ValueError.
-        with self.assertRaises(ValueError):
-            self.execute(data01, '../data01/utf-8.file')
-
     def test_importing_module_as_side_effect(self):
         # The anchor package can already be imported.
         del sys.modules[data01.__name__]


### PR DESCRIPTION
- Port test_contents to files API
- Remove tests for relative/absolute paths, no longer relevant. Move normalize_path to _legacy.
- Port test_open to traversable API.
- Port test_path to traversable API.
- Port test_read to traversable API.
- Port test_resource to traversable API.
- Remove 'suppress_known_deprecation' helper.
