### PR TITLE
fix(types): Adding some typing from typeshed

### DIFF
--- a/importlib_resources/_compat.py
+++ b/importlib_resources/_compat.py
@@ -1,9 +1,12 @@
 # flake8: noqa
 
 import abc
+import os
 import sys
 import pathlib
 from contextlib import suppress
+from typing import Union
+
 
 if sys.version_info >= (3, 10):
     from zipfile import Path as ZipPath  # type: ignore
@@ -96,3 +99,10 @@ def wrap_spec(package):
     from . import _adapters
 
     return _adapters.SpecLoaderAdapter(package.__spec__, TraversableResourcesLoader)
+
+
+if sys.version_info >= (3, 9):
+    StrPath = Union[str, os.PathLike[str]]
+else:
+    # PathLike is only subscriptable at runtime in 3.9+
+    StrPath = Union[str, "os.PathLike[str]"]

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,6 +1,6 @@
 import abc
+import io
 from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text, Optional
-from io import BufferedReader
 
 from ._compat import runtime_checkable, Protocol, StrPath
 
@@ -128,7 +128,7 @@ class TraversableResources(ResourceReader):
     def files(self) -> "Traversable":
         """Return a Traversable object for the loaded package."""
 
-    def open_resource(self, resource: StrPath) -> BufferedReader:
+    def open_resource(self, resource: StrPath) -> io.BufferedReader:
         return self.files().joinpath(resource).open('rb')
 
     def resource_path(self, resource: Any) -> NoReturn:

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,17 +1,11 @@
 import abc
-from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text
+from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text, Optional
 from io import BufferedReader
-from typing import Union, Optional
-from os import PathLike
 
-from ._compat import runtime_checkable, Protocol
+from ._compat import runtime_checkable, Protocol, StrPath
 
 
 __all__ = ["ResourceReader", "Traversable", "TraversableResources"]
-
-
-# PathLike is only subscriptable at runtime in 3.9+
-StrPath = Union[str, "PathLike[str]"]
 
 
 class ResourceReader(metaclass=abc.ABCMeta):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -10,7 +10,8 @@ from ._compat import runtime_checkable, Protocol
 __all__ = ["ResourceReader", "Traversable", "TraversableResources"]
 
 
-StrPath = Union[str, PathLike[str]]
+# PathLike is only subscriptable at runtime in 3.9+
+StrPath = Union[str, "PathLike[str]"]
 
 
 class ResourceReader(metaclass=abc.ABCMeta):

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,7 +1,16 @@
 import abc
-from typing import BinaryIO, Iterable, Text
+from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text
+from io import BufferedReader
+from typing import Union, Optional
+from os import PathLike
 
 from ._compat import runtime_checkable, Protocol
+
+
+__all__ = ["ResourceReader", "Traversable", "TraversableResources"]
+
+
+StrPath = Union[str, PathLike[str]]
 
 
 class ResourceReader(metaclass=abc.ABCMeta):
@@ -54,19 +63,19 @@ class Traversable(Protocol):
     """
 
     @abc.abstractmethod
-    def iterdir(self):
+    def iterdir(self) -> Iterator["Traversable"]:
         """
         Yield Traversable objects in self
         """
 
-    def read_bytes(self):
+    def read_bytes(self) -> bytes:
         """
         Read contents of self as bytes
         """
         with self.open('rb') as strm:
             return strm.read()
 
-    def read_text(self, encoding=None):
+    def read_text(self, encoding: Optional[str] = None) -> str:
         """
         Read contents of self as text
         """
@@ -86,12 +95,12 @@ class Traversable(Protocol):
         """
 
     @abc.abstractmethod
-    def joinpath(self, child):
+    def joinpath(self, child: StrPath) -> "Traversable":
         """
         Return Traversable child in self
         """
 
-    def __truediv__(self, child):
+    def __truediv__(self, child: StrPath) -> "Traversable":
         """
         Return Traversable child in self
         """
@@ -121,17 +130,17 @@ class TraversableResources(ResourceReader):
     """
 
     @abc.abstractmethod
-    def files(self):
+    def files(self) -> "Traversable":
         """Return a Traversable object for the loaded package."""
 
-    def open_resource(self, resource):
+    def open_resource(self, resource: StrPath) -> BufferedReader:
         return self.files().joinpath(resource).open('rb')
 
-    def resource_path(self, resource):
+    def resource_path(self, resource: Any) -> NoReturn:
         raise FileNotFoundError(resource)
 
-    def is_resource(self, path):
+    def is_resource(self, path: StrPath) -> bool:
         return self.files().joinpath(path).is_file()
 
-    def contents(self):
+    def contents(self) -> Iterator[str]:
         return (item.name for item in self.files().iterdir())


### PR DESCRIPTION
Adding some types from https://github.com/python/typeshed/blob/master/stdlib/importlib/abc.pyi - everything except `.open`, which is a bit more complex to get right, so leaving it alone for this pass, can add it also later.
