### PR TITLE
Re-use joinpath logic in Traversable and MultiplexedPath

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v5.8.0
+======
+
+* #250: Now ``Traversable.joinpath`` provides a concrete
+  implementation, replacing the implementation in ``.simple``
+  and converging with the behavior in ``MultiplexedPath``.
+
 v5.7.1
 ======
 

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -92,7 +92,6 @@ class Traversable(Protocol):
         Return True if self is a file
         """
 
-    @abc.abstractmethod
     def joinpath(self, *descendants: StrPath) -> "Traversable":
         """
         Return Traversable resolved with any descendants applied.
@@ -101,6 +100,13 @@ class Traversable(Protocol):
         and each may contain multiple levels separated by
         ``posixpath.sep`` (``/``).
         """
+        if not descendants:
+            return self
+        names = (name for compound in descendants for name in compound.split('/'))
+        target = next(names)
+        return next(
+            traversable for traversable in self.iterdir() if traversable.name == target
+        ).joinpath(*names)
 
     def __truediv__(self, child: StrPath) -> "Traversable":
         """

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,5 +1,7 @@
 import abc
 import io
+import itertools
+import pathlib
 from typing import Any, BinaryIO, Iterable, Iterator, NoReturn, Text, Optional
 
 from ._compat import runtime_checkable, Protocol, StrPath
@@ -102,7 +104,9 @@ class Traversable(Protocol):
         """
         if not descendants:
             return self
-        names = (name for compound in descendants for name in compound.split('/'))
+        names = itertools.chain.from_iterable(
+            path.parts for path in map(pathlib.PurePosixPath, descendants)
+        )
         target = next(names)
         return next(
             traversable for traversable in self.iterdir() if traversable.name == target

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -116,11 +116,12 @@ class Traversable(Protocol):
             traversable for traversable in self.iterdir() if traversable.name == target
         )
         try:
-            return next(matches).joinpath(*names)
+            match = next(matches)
         except StopIteration:
             raise TraversalError(
                 "Target not found during traversal.", target, list(names)
             )
+        return match.joinpath(*names)
 
     def __truediv__(self, child: StrPath) -> "Traversable":
         """

--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -82,15 +82,16 @@ class MultiplexedPath(abc.Traversable):
     def is_file(self):
         return False
 
-    def joinpath(self, child):
-        # first try to find child in current paths
-        for file in self.iterdir():
-            if file.name == child:
-                return file
-        # if it does not exist, construct it with the first path
-        return self._paths[0] / child
-
-    __truediv__ = joinpath
+    def joinpath(self, *descendants):
+        try:
+            return super().joinpath(*descendants)
+        except abc.TraversalError as exc:
+            # One of the paths didn't resolve.
+            msg, target, names = exc.args
+            if names:
+                raise
+            # It was the last; construct result with the first path.
+            return self._paths[0].joinpath(target)
 
     def open(self, *args, **kwargs):
         raise FileNotFoundError(f'{self} is not a file')

--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -88,7 +88,7 @@ class MultiplexedPath(abc.Traversable):
         except abc.TraversalError as exc:
             # One of the paths didn't resolve.
             msg, target, names = exc.args
-            if names:
+            if names:  # pragma: nocover
                 raise
             # It was the last; construct result with the first path.
             return self._paths[0].joinpath(target)

--- a/importlib_resources/simple.py
+++ b/importlib_resources/simple.py
@@ -99,15 +99,14 @@ class ResourceContainer(Traversable):
     def open(self, *args, **kwargs):
         raise IsADirectoryError()
 
-    @staticmethod
-    def _flatten(compound_names):
-        for name in compound_names:
-            yield from name.split('/')
-
     def joinpath(self, *descendants):
         if not descendants:
             return self
-        names = self._flatten(descendants)
+        names = (
+            name
+            for compound in descendants
+            for name in compound.split('/')
+        )
         target = next(names)
         return next(
             traversable for traversable in self.iterdir() if traversable.name == target

--- a/importlib_resources/simple.py
+++ b/importlib_resources/simple.py
@@ -99,19 +99,6 @@ class ResourceContainer(Traversable):
     def open(self, *args, **kwargs):
         raise IsADirectoryError()
 
-    def joinpath(self, *descendants):
-        if not descendants:
-            return self
-        names = (
-            name
-            for compound in descendants
-            for name in compound.split('/')
-        )
-        target = next(names)
-        return next(
-            traversable for traversable in self.iterdir() if traversable.name == target
-        ).joinpath(*names)
-
 
 class TraversableReader(TraversableResources, SimpleReader):
     """

--- a/importlib_resources/tests/test_reader.py
+++ b/importlib_resources/tests/test_reader.py
@@ -75,6 +75,7 @@ class MultiplexedPathTest(unittest.TestCase):
             str(path.joinpath('imaginary'))[len(prefix) + 1 :],
             os.path.join('namespacedata01', 'imaginary'),
         )
+        self.assertEqual(path.joinpath(), path)
 
     def test_repr(self):
         self.assertEqual(


### PR DESCRIPTION
Inspired by https://github.com/python/importlib_resources/pull/248#discussion_r850586361

- Inline the flattening of descendants.
- Move ResourceContainer.joinpath to Traversable.joinpath, providing a concrete implementation.
- Refactor to converge descendants to a single type and rely on Path.parts for getting the parts.
- Replace StopIteration with a TraversalError for use in capturing a failed traversal.
- In readers.MultiplexedPath, re-use Traversable.joinpath.
