### PR TITLE
Restore lenience in MultiplexedPath.joinpath for missing directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v5.8.1
+======
+
+* #253: In ``MultiplexedPath``, restore expectation that
+  a compound path with a non-existent directory does not
+  raise an exception.
+
 v5.8.0
 ======
 

--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -85,13 +85,10 @@ class MultiplexedPath(abc.Traversable):
     def joinpath(self, *descendants):
         try:
             return super().joinpath(*descendants)
-        except abc.TraversalError as exc:
-            # One of the paths didn't resolve.
-            msg, target, names = exc.args
-            if names:  # pragma: nocover
-                raise
-            # It was the last; construct result with the first path.
-            return self._paths[0].joinpath(target)
+        except abc.TraversalError:
+            # One of the paths did not resolve (a directory does not exist).
+            # Just return something that will not exist.
+            return self._paths[0].joinpath(*descendants)
 
     def open(self, *args, **kwargs):
         raise FileNotFoundError(f'{self} is not a file')

--- a/importlib_resources/tests/test_reader.py
+++ b/importlib_resources/tests/test_reader.py
@@ -3,8 +3,6 @@ import sys
 import pathlib
 import unittest
 
-import pytest
-
 from importlib import import_module
 from importlib_resources.readers import MultiplexedPath, NamespaceReader
 
@@ -79,7 +77,6 @@ class MultiplexedPathTest(unittest.TestCase):
         )
         self.assertEqual(path.joinpath(), path)
 
-    @pytest.mark.xfail(reason="#253")
     def test_join_path_compound(self):
         path = MultiplexedPath(self.folder)
         assert not path.joinpath('imaginary/foo.py').exists()


### PR DESCRIPTION
- Add test capturing expectation revealed by #253.
- Suppress all TraversalErrors in MultiplexedPath. Fixes #253.
- Update changelog. Ref #253.
