### PR TITLE
Add support for rendering a local copy of resources on the file system

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v5.9.0
+======
+
+* #228: ``as_file`` now also supports a ``Traversable``
+  representing a directory and (when needed) renders the
+  full tree to a temporary directory.
+
 v5.8.0
 ======
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -6,7 +6,7 @@ import contextlib
 import types
 import importlib
 
-from typing import Union, Optional, ContextManager
+from typing import Union, Optional
 from .abc import ResourceReader, Traversable
 
 from ._compat import wrap_spec
@@ -94,7 +94,7 @@ def _tempfile(
 
 
 @functools.singledispatch
-def as_file(path: Traversable) -> pathlib.Path:
+def as_file(path):
     """
     Given a Traversable object, return that object as a
     path on the local file system in a context manager.
@@ -112,7 +112,7 @@ def _(path):
 
 
 @contextlib.contextmanager
-def _temp_path(dir: tempfile.TemporaryDirectory) -> ContextManager[pathlib.Path]:
+def _temp_path(dir: tempfile.TemporaryDirectory):
     """
     Wrap tempfile.TemporyDirectory to return a pathlib object.
     """
@@ -121,7 +121,7 @@ def _temp_path(dir: tempfile.TemporaryDirectory) -> ContextManager[pathlib.Path]
 
 
 @contextlib.contextmanager
-def _as_tree(path: Traversable) -> pathlib.Path:
+def _as_tree(path):
     """
     Given a traversable dir, recursively replicate the whole tree
     to the file system in a context manager.
@@ -132,7 +132,7 @@ def _as_tree(path: Traversable) -> pathlib.Path:
         yield temp_dir
 
 
-def _write_contents(target: pathlib.Path, source: Traversable):
+def _write_contents(target, source):
     for item in source.iterdir():
         child = target.joinpath(item.name)
         if item.is_dir():

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -136,16 +136,16 @@ def _temp_dir(path):
     to the file system in a context manager.
     """
     assert path.is_dir()
-    with _temp_path(tempfile.TemporaryDirectory(suffix=path.name)) as temp_dir:
-        _write_contents(temp_dir, path)
-        yield temp_dir
+    with _temp_path(tempfile.TemporaryDirectory()) as temp_dir:
+        yield _write_contents(temp_dir, path)
 
 
 def _write_contents(target, source):
-    for item in source.iterdir():
-        child = target.joinpath(item.name)
-        if item.is_dir():
-            child.mkdir()
+    child = target.joinpath(source.name)
+    if source.is_dir():
+        child.mkdir()
+        for item in source.iterdir():
             _write_contents(child, item)
-        else:
-            child.open('wb').write(item.read_bytes())
+    else:
+        child.open('wb').write(source.read_bytes())
+    return child

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -93,13 +93,22 @@ def _tempfile(
             pass
 
 
+def _temp_file(path):
+    return _tempfile(path.read_bytes, suffix=path.name)
+
+
 @functools.singledispatch
 def as_file(path):
     """
     Given a Traversable object, return that object as a
     path on the local file system in a context manager.
     """
-    return _tempfile(path.read_bytes, suffix=path.name)
+    try:
+        is_dir = path.is_dir()
+    except FileNotFoundError:
+        is_dir = False
+
+    return _temp_dir(path) if is_dir else _temp_file(path)
 
 
 @as_file.register(pathlib.Path)
@@ -121,7 +130,7 @@ def _temp_path(dir: tempfile.TemporaryDirectory):
 
 
 @contextlib.contextmanager
-def _as_tree(path):
+def _temp_dir(path):
     """
     Given a traversable dir, recursively replicate the whole tree
     to the file system in a context manager.

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -111,6 +111,14 @@ class ResourceFromZipsTest01(util.ZipSetupBase, unittest.TestCase):
             {'__init__.py', 'binary.file'},
         )
 
+    def test_as_file_directory(self):
+        with resources.as_file(resources.files('ziptestdata')) as data:
+            assert data.name == 'ziptestdata'
+            assert data.is_dir()
+            assert data.joinpath('subdirectory').is_dir()
+            assert len(list(data.iterdir()))
+        assert not data.parent.exists()
+
 
 class ResourceFromZipsTest02(util.ZipSetupBase, unittest.TestCase):
     ZIP_MODULE = zipdata02  # type: ignore


### PR DESCRIPTION
Fixes #228 

- Add _common._as_tree to demonstrate a directory of resources.
- Remove type hints as they're causing trouble.
- Allow as_file to return a context manager for a directory or a file as needed.
- Rewrite _temp_dir so that it produces a directory of the same name as the input path.
