### PR TITLE
Docs: Change isdir() to is_dir()

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -148,7 +148,7 @@ a package is a directory or not::
 
 The ``importlib_resources`` equivalent is straightforward::
 
-    if importlib_resources.files('my.package').joinpath('resource').isdir():
+    if importlib_resources.files('my.package').joinpath('resource').is_dir():
         print('A directory')
 
 


### PR DESCRIPTION
For Path objects, the function name contains an underscore.
https://docs.python.org/3/library/pathlib.html#pathlib.Path.is_dir