### PR TITLE
Fix ResourceWarning due to unclosed file resource.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v5.10.1
+=======
+
+* #274: Fixed ``ResourceWarning`` in ``_common``.
+
 v5.10.0
 =======
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -203,5 +203,6 @@ def _write_contents(target, source):
         for item in source.iterdir():
             _write_contents(child, item)
     else:
-        child.open('wb').write(source.read_bytes())
+        with child.open('wb') as fp:
+            fp.write(source.read_bytes())
     return child


### PR DESCRIPTION
Fixes below warnings that were originally found in CPython test suite.

```
============================================================================= warnings summary ==============================================================================
importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/utf-16.file'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/utf-8.file'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/__init__.py'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/binary.file'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/subdirectory/__init__.py'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

importlib_resources/tests/test_resource.py::ResourceFromZipsTest01::test_as_file_directory
  /home/karthikeyan/stuff/python/importlib_resources/importlib_resources/_common.py:206: ResourceWarning: unclosed file <_io.BufferedWriter name='/tmp/tmpekn15a6u/ziptestdata/subdirectory/binary.file'>
    child.open('wb').write(source.read_bytes())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```