### PR TITLE
Use NoneType instead of None for type annotation.

### DIFF
--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -17,6 +17,10 @@ from ._compat import wrap_spec
 Package = Union[types.ModuleType, str]
 Anchor = Package
 
+try:
+  NoneType = types.NoneType
+except AttributeError: # Python < 3.10
+  NoneType = type(None)
 
 def package_to_anchor(func):
     """
@@ -83,7 +87,7 @@ def _(cand: str) -> types.ModuleType:
 
 
 @resolve.register
-def _(cand: None) -> types.ModuleType:
+def _(cand: NoneType) -> types.ModuleType:
     return resolve(_infer_caller().f_globals['__name__'])
 
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -18,9 +18,10 @@ Package = Union[types.ModuleType, str]
 Anchor = Package
 
 try:
-  NoneType = types.NoneType
-except AttributeError: # Python < 3.10
-  NoneType = type(None)
+    NoneType = types.NoneType
+except AttributeError:  # Python < 3.10
+    NoneType = type(None)
+
 
 def package_to_anchor(func):
     """


### PR DESCRIPTION
This was causing our sphinx docs builds to crash with:

```
..snip..
File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/etils/epath/resource_utils.py", line [34](https://github.com/deepmind/dm-haiku/actions/runs/3958676572/jobs/6780528507#step:6:35), in <module>
    import importlib_resources
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/importlib_resources/__init__.py", line 3, in <module>
    from ._common import (
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/importlib_resources/_common.py", line 86, in <module>
    def _(cand: None) -> types.ModuleType:
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/functools.py", line 860, in register
    raise TypeError(
TypeError: Invalid annotation for 'cand'. None is not a class.
```

It seems like other users may have also been affected: https://www.mail-archive.com/sphinx-users@googlegroups.com/msg05052.html