### PR TITLE
Fixed handling of namespace packages in zip files

### DIFF
--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -136,12 +136,12 @@ class NamespaceReader(abc.TraversableResources):
 
     @classmethod
     def _resolve(cls, path_str) -> abc.Traversable:
-        """
+        r"""
         Given an item from a namespace path, resolve it to a Traversable.
 
         path_str might be a directory on the filesystem or a path to a
         zipfile plus the path within the zipfile, e.g. ``/foo/bar`` or
-        ``/foo/baz.zip/inner_dir``.
+        ``/foo/baz.zip/inner_dir`` or ``foo\baz.zip\inner_dir\sub``.
         """
         (dir,) = (cand for cand in cls._candidate_paths(path_str) if cand.is_dir())
         return dir
@@ -153,10 +153,12 @@ class NamespaceReader(abc.TraversableResources):
 
     @staticmethod
     def _resolve_zip_path(path_str):
-        for match in reversed(list(re.finditer('/', path_str))):
-            with contextlib.suppress(FileNotFoundError, IsADirectoryError):
-                inner = path_str[match.end() :]
-                yield ZipPath(path_str[: match.start()], inner + '/' * len(inner))
+        for match in reversed(list(re.finditer(r'[\\/]', path_str))):
+            with contextlib.suppress(
+                FileNotFoundError, IsADirectoryError, PermissionError
+            ):
+                inner = path_str[match.end() :].replace('\\', '/') + '/'
+                yield ZipPath(path_str[: match.start()], inner.lstrip('/'))
 
     def resource_path(self, resource):
         """

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -3,8 +3,6 @@ import unittest
 import importlib_resources as resources
 import pathlib
 
-import pytest
-
 from . import data01
 from . import util
 from importlib import import_module
@@ -211,7 +209,6 @@ class ResourceFromNamespaceDiskTests(ResourceFromNamespaceTests, unittest.TestCa
         sys.path.remove(cls.site_dir)
 
 
-@pytest.mark.xfail
 class ResourceFromNamespaceZipTests(
     util.ZipSetupBase,
     ResourceFromNamespaceTests,

--- a/newsfragments/287.bugfix.rst
+++ b/newsfragments/287.bugfix.rst
@@ -1,0 +1,1 @@
+Enabled support for resources in namespace packages in zip files.


### PR DESCRIPTION
- When constructing a MultiplexedPath, resolve submodule_search_locations to Traversable objects. Closes python/importlib_resources#287.
