### PR TITLE
Fix regression and restore stdlib reader suppression on Python 3.10

### DIFF
--- a/importlib_resources/future/adapters.py
+++ b/importlib_resources/future/adapters.py
@@ -24,7 +24,8 @@ def _block_standard(reader_getter):
             # MultiplexedPath may fail on zip subdirectory
             return
         # Python 3.10+
-        if reader.__class__.__module__.startswith('importlib.resources.'):
+        mod_name = reader.__class__.__module__
+        if mod_name.startswith('importlib.') and mod_name.endswith('readers'):
             return
         # Python 3.8, 3.9
         if isinstance(reader, _adapters.CompatibilityFiles) and (

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -34,6 +34,11 @@ class FilesTests:
     def test_traversable(self):
         assert isinstance(resources.files(self.data), Traversable)
 
+    def test_joinpath_with_multiple_args(self):
+        files = resources.files(self.data)
+        binfile = files.joinpath('subdirectory', 'binary.file')
+        self.assertTrue(binfile.is_file())
+
     def test_old_parameter(self):
         """
         Files used to take a 'package' parameter. Make sure anyone

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -4,6 +4,8 @@ import warnings
 import importlib
 import contextlib
 
+import pytest
+
 import importlib_resources as resources
 from ..abc import Traversable
 from . import data01
@@ -34,6 +36,7 @@ class FilesTests:
     def test_traversable(self):
         assert isinstance(resources.files(self.data), Traversable)
 
+    @pytest.mark.xfail("sys.version_info[:2] == (3, 10)", reason="#257")
     def test_joinpath_with_multiple_args(self):
         files = resources.files(self.data)
         binfile = files.joinpath('subdirectory', 'binary.file')

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -4,8 +4,6 @@ import warnings
 import importlib
 import contextlib
 
-import pytest
-
 import importlib_resources as resources
 from ..abc import Traversable
 from . import data01
@@ -36,7 +34,6 @@ class FilesTests:
     def test_traversable(self):
         assert isinstance(resources.files(self.data), Traversable)
 
-    @pytest.mark.xfail("sys.version_info[:2] == (3, 10)", reason="#257")
     def test_joinpath_with_multiple_args(self):
         files = resources.files(self.data)
         binfile = files.joinpath('subdirectory', 'binary.file')

--- a/newsfragments/257.bugfix.rst
+++ b/newsfragments/257.bugfix.rst
@@ -1,0 +1,1 @@
+Restored expectation that stdlib readers are suppressed on Python 3.10.


### PR DESCRIPTION
- **Add test capturing missed expectation. Ref #257.**
- **Mark test as xfail on Python 3.10 where it fails. Ref #257.**
- **Ensure stdlib readers are excluded on Python 3.10 even when found in importlib.readers. Closes #257.**
- **Add news fragment.**
