### PR TITLE
Restore precedence of standard readers over degenerate readers

### DIFF
--- a/importlib_resources/future/adapters.py
+++ b/importlib_resources/future/adapters.py
@@ -40,6 +40,16 @@ def _block_standard(reader_getter):
     return wrapper
 
 
+def _skip_degenerate(reader):
+    """
+    Mask any degenerate reader.
+    """
+    is_degenerate = (
+        isinstance(reader, _adapters.CompatibilityFiles) and not reader._reader
+    )
+    return reader if not is_degenerate else None
+
+
 class TraversableResourcesLoader(_adapters.TraversableResourcesLoader):
     """
     Adapt loaders to provide TraversableResources and other
@@ -51,8 +61,9 @@ class TraversableResourcesLoader(_adapters.TraversableResourcesLoader):
 
     def get_resource_reader(self, name):
         return (
-            _block_standard(super().get_resource_reader)(name)
+            _skip_degenerate(_block_standard(super().get_resource_reader)(name))
             or self._standard_reader()
+            or super().get_resource_reader(name)
         )
 
     def _standard_reader(self):

--- a/importlib_resources/future/adapters.py
+++ b/importlib_resources/future/adapters.py
@@ -42,7 +42,7 @@ def _block_standard(reader_getter):
 
 def _skip_degenerate(reader):
     """
-    Mask any degenerate reader.
+    Mask any degenerate reader. Ref #298.
     """
     is_degenerate = (
         isinstance(reader, _adapters.CompatibilityFiles) and not reader._reader

--- a/newsfragments/298.bugfix.rst
+++ b/newsfragments/298.bugfix.rst
@@ -1,0 +1,1 @@
+Restored expectation that local standard readers are preferred over degenerate readers.


### PR DESCRIPTION
- **When blocking stdlib readers, avoid giving deference to degenerate readers and instead prefer the standard readers before once again falling back to any CompatibilityFiles reader. Closes #298.**
- **Add news fragment.**
