### PR TITLE
Fix functional API tests to be endian-agnostic

### DIFF
--- a/importlib_resources/tests/test_functional.py
+++ b/importlib_resources/tests/test_functional.py
@@ -82,7 +82,7 @@ class FunctionalAPIBase:
                 'utf-16.file',
                 errors='backslashreplace',
             ),
-            'Hello, UTF-16 world!\n'.encode('utf-16').decode(
+            '\ufeffHello, UTF-16 world!\n'.encode('utf-16-le').decode(
                 errors='backslashreplace',
             ),
         )
@@ -130,7 +130,7 @@ class FunctionalAPIBase:
         ) as f:
             self.assertEqual(
                 f.read(),
-                'Hello, UTF-16 world!\n'.encode('utf-16').decode(
+                '\ufeffHello, UTF-16 world!\n'.encode('utf-16-le').decode(
                     errors='backslashreplace',
                 ),
             )


### PR DESCRIPTION
Fix the "backslashreplace" tests for the functional API to be endian-agnostic.  The tests used to rely on `.encode("utf-16")` producing the same data as found in the test file.  However, on big endian platforms it would produce a big endian encoding, while the test file is little endian.  To avoid the problem, explicitly specify `utf-16-le` encoding.  Since this meant that the BOM is no longer produced, explicitly include it in input.

Fixes #312