### PR TITLE
Fix issue in inferred caller when resourcse package has no source.

### DIFF
--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -91,9 +91,14 @@ def _infer_caller():
     """
     Walk the stack and find the frame of the first caller not in this module.
     """
+    this_frame = inspect.currentframe()
+    if this_frame is None:
+        this_file = __file__
+    else:
+        this_file = inspect.getframeinfo(this_frame).filename
 
     def is_this_file(frame_info):
-        return frame_info.filename == __file__
+        return frame_info.filename == this_file
 
     def is_wrapper(frame_info):
         return frame_info.function == 'wrapper'

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -87,18 +87,19 @@ def _(cand: None) -> types.ModuleType:
     return resolve(_infer_caller().f_globals['__name__'])
 
 
+@functools.lru_cache
+def _this_filename():
+    frame = inspect.currentframe()
+    return __file__ if frame is None else inspect.getframeinfo(frame).filename
+
+
 def _infer_caller():
     """
     Walk the stack and find the frame of the first caller not in this module.
     """
-    this_frame = inspect.currentframe()
-    if this_frame is None:
-        this_file = __file__
-    else:
-        this_file = inspect.getframeinfo(this_frame).filename
 
     def is_this_file(frame_info):
-        return frame_info.filename == this_file
+        return frame_info.filename == _this_filename()
 
     def is_wrapper(frame_info):
         return frame_info.function == 'wrapper'

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -87,24 +87,19 @@ def _(cand: None) -> types.ModuleType:
     return resolve(_infer_caller().f_globals['__name__'])
 
 
-@functools.lru_cache
-def _this_filename():
-    frame = inspect.currentframe()
-    return __file__ if frame is None else inspect.getframeinfo(frame).filename
-
-
 def _infer_caller():
     """
     Walk the stack and find the frame of the first caller not in this module.
     """
 
     def is_this_file(frame_info):
-        return frame_info.filename == _this_filename()
+        return frame_info.filename == stack[0].filename
 
     def is_wrapper(frame_info):
         return frame_info.function == 'wrapper'
 
-    not_this_file = itertools.filterfalse(is_this_file, inspect.stack())
+    stack = inspect.stack()
+    not_this_file = itertools.filterfalse(is_this_file, stack)
     # also exclude 'wrapper' due to singledispatch in the call stack
     callers = itertools.filterfalse(is_wrapper, not_this_file)
     return next(callers).frame

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -102,8 +102,8 @@ class ModuleFilesZipTests(DirectSpec, util.ZipSetup, ModulesFiles, unittest.Test
 
 class ImplicitContextFiles:
     set_val = textwrap.dedent(
-        """
-        import importlib_resources as res
+        f"""
+        import {resources.__name__} as res
         val = res.files().joinpath('res.txt').read_text(encoding='utf-8')
         """
     )
@@ -114,7 +114,7 @@ class ImplicitContextFiles:
             'res.txt': 'resources are the best',
         },
         'frozenpkg': {
-            '__init__.py': set_val.replace('importlib_resources', 'c_resources'),
+            '__init__.py': set_val.replace(resources.__name__, 'c_resources'),
             'res.txt': 'resources are the best',
         },
     }

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -149,6 +149,11 @@ class ImplicitContextFiles:
         self.fixtures.enter_context(import_helper.DirsOnSysPath(bin_site))
 
     def test_implicit_files_with_compiled_importlib(self):
+        """
+        Caller detection works for compiled-only resources module.
+
+        python/cpython#123085
+        """
         self._compile_importlib()
         assert importlib.import_module('frozenpkg').val == 'resources are the best'
 

--- a/newsfragments/+0f77c990.bugfix.rst
+++ b/newsfragments/+0f77c990.bugfix.rst
@@ -1,0 +1,1 @@
+When inferring the caller in ``files()`` correctly detect one's own module even when the resources package source is not present. (python/cpython#123085)


### PR DESCRIPTION
Closes python/cpython#123085

- **gh-121735: Fix inferring caller when resolving importlib.resources.files()**
- **Adapt changes for new fixtures.**
- **Extract a function for computing 'this filename' once.**
- **Just do a simple textual substitution to avoid under matching when the file is compiled.**
