### PR TITLE
Omit non-dir items when constructing a NamespaceReader

### DIFF
--- a/importlib_resources/readers.py
+++ b/importlib_resources/readers.py
@@ -138,19 +138,23 @@ class NamespaceReader(abc.TraversableResources):
     def __init__(self, namespace_path):
         if 'NamespacePath' not in str(namespace_path):
             raise ValueError('Invalid path')
-        self.path = MultiplexedPath(*map(self._resolve, namespace_path))
+        self.path = MultiplexedPath(*filter(bool, map(self._resolve, namespace_path)))
 
     @classmethod
-    def _resolve(cls, path_str) -> abc.Traversable:
+    def _resolve(cls, path_str) -> abc.Traversable | None:
         r"""
         Given an item from a namespace path, resolve it to a Traversable.
 
         path_str might be a directory on the filesystem or a path to a
         zipfile plus the path within the zipfile, e.g. ``/foo/bar`` or
         ``/foo/baz.zip/inner_dir`` or ``foo\baz.zip\inner_dir\sub``.
+
+        path_str might also be a sentinel used by editable packages to
+        trigger other behaviors (see python/importlib_resources#311).
+        In that case, return None.
         """
-        (dir,) = (cand for cand in cls._candidate_paths(path_str) if cand.is_dir())
-        return dir
+        dirs = (cand for cand in cls._candidate_paths(path_str) if cand.is_dir())
+        return next(dirs, None)
 
     @classmethod
     def _candidate_paths(cls, path_str: str) -> Iterator[abc.Traversable]:

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -8,8 +8,6 @@ import warnings
 import importlib
 import contextlib
 
-import pytest
-
 import importlib_resources as resources
 from ..abc import Traversable
 from . import util
@@ -62,7 +60,6 @@ class OpenZipTests(FilesTests, util.ZipSetup, unittest.TestCase):
 class OpenNamespaceTests(FilesTests, util.DiskSetup, unittest.TestCase):
     MODULE = 'namespacedata01'
 
-    @pytest.mark.xfail(reason="#311")
     def test_non_paths_in_dunder_path(self):
         """
         Non-path items in a namespace package's ``__path__`` are ignored.

--- a/newsfragments/311.bugfix.rst
+++ b/newsfragments/311.bugfix.rst
@@ -1,0 +1,1 @@
+Omit sentinel values from a namespace path.


### PR DESCRIPTION
Closes #311 

- **Add test capturing failure when resolving the MultiplexedPath for a namespace package with non-path elements in the path.**
- **Omit sentinel values from a namespace path.**
