### PR TITLE
Resolve two test suite failures

### DIFF
--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -1,7 +1,5 @@
-import os
 import pathlib
 import py_compile
-import shutil
 import textwrap
 import unittest
 import warnings

--- a/importlib_resources/tests/test_functional.py
+++ b/importlib_resources/tests/test_functional.py
@@ -182,17 +182,23 @@ class FunctionalAPIBase(util.DiskSetup):
             set(c),
             {'utf-8.file', 'utf-16.file', 'binary.file', 'subdirectory'},
         )
-        with self.assertRaises(OSError), warnings_helper.check_warnings((
-            ".*contents.*",
-            DeprecationWarning,
-        )):
+        with (
+            self.assertRaises(OSError),
+            warnings_helper.check_warnings((
+                ".*contents.*",
+                DeprecationWarning,
+            )),
+        ):
             list(resources.contents(self.anchor01, 'utf-8.file'))
 
         for path_parts in self._gen_resourcetxt_path_parts():
-            with self.assertRaises(OSError), warnings_helper.check_warnings((
-                ".*contents.*",
-                DeprecationWarning,
-            )):
+            with (
+                self.assertRaises(OSError),
+                warnings_helper.check_warnings((
+                    ".*contents.*",
+                    DeprecationWarning,
+                )),
+            ):
                 list(resources.contents(self.anchor01, *path_parts))
         with warnings_helper.check_warnings((".*contents.*", DeprecationWarning)):
             c = resources.contents(self.anchor01, 'subdirectory')


### PR DESCRIPTION
This PR resolves two test suite failures ([recent CI example](https://github.com/python/importlib_resources/actions/runs/11639417045/job/32415561859#step:5:134)):

* Unused imports in `test_files.py`
* Formatting in `test_functional.py`

This is a purely mechanical change introduced by running `pre-commit run -a`.

---

I tested locally against Python 3.9+ by introducing a tox `envlist` and then running `tox` to confirm the failures were resolved:

```ini
[tox]
envlist =
	py{3.13, 3.12, 3.11, 3.10, 3.9}
```

If this tox change is desirable in general, let me know and I'll submit an additional PR so that local test suite runs exercise all supported CPython versions.