### PR TITLE
Defer `tempfile` import to sites of use

### DIFF
--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -5,7 +5,6 @@ import inspect
 import itertools
 import os
 import pathlib
-import tempfile
 import types
 import warnings
 from typing import Optional, Union, cast
@@ -127,6 +126,9 @@ def _tempfile(
     *,
     _os_remove=os.remove,
 ):
+    # Deferred for performance.
+    import tempfile
+
     # Not using tempfile.NamedTemporaryFile as it leads to deeper 'try'
     # blocks due to the need to close the temporary file to work on Windows
     # properly.
@@ -186,6 +188,9 @@ def _temp_dir(path):
     Given a traversable dir, recursively replicate the whole tree
     to the file system in a context manager.
     """
+    # Deferred for performance.
+    import tempfile
+
     assert path.is_dir()
     with tempfile.TemporaryDirectory() as temp_dir:
         yield _write_contents(pathlib.Path(temp_dir), path)

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -181,23 +181,14 @@ def _(path):
 
 
 @contextlib.contextmanager
-def _temp_path(dir: tempfile.TemporaryDirectory):
-    """
-    Wrap tempfile.TemporaryDirectory to return a pathlib object.
-    """
-    with dir as result:
-        yield pathlib.Path(result)
-
-
-@contextlib.contextmanager
 def _temp_dir(path):
     """
     Given a traversable dir, recursively replicate the whole tree
     to the file system in a context manager.
     """
     assert path.is_dir()
-    with _temp_path(tempfile.TemporaryDirectory()) as temp_dir:
-        yield _write_contents(temp_dir, path)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield _write_contents(pathlib.Path(temp_dir), path)
 
 
 def _write_contents(target, source):


### PR DESCRIPTION
Part of #326.

`tempfile` is a relatively heavy import that's only used in a few routines, and they aren't always called when using `importlib_resources`, especially in the common case of `as_file()` being passed a `pathlib.Path` object. Thus, I think it's worthwhile to defer importing it until it's actually used.

This PR effectively inlines the one function using `tempfile` at module-level scope to avoid an import-time dependency on `tempfile`. It then "inlines" the necessary import in the two functions that use it.

Based on local testing, doing so improves the upfront import time of `importlib_resources`by about ~30% on supported CPython versions and ~50% on PyPy3.10.


