### PR TITLE
Avoid import-time dependency on `typing` in common cases

### DIFF
--- a/importlib_resources/__init__.py
+++ b/importlib_resources/__init__.py
@@ -8,8 +8,6 @@ for more detail.
 """
 
 from ._common import (
-    Anchor,
-    Package,
     as_file,
     files,
 )
@@ -38,3 +36,28 @@ __all__ = [
     'read_binary',
     'read_text',
 ]
+
+TYPE_CHECKING = False
+
+# Type checkers needs this block to understand what __getattr__() exports currently.
+if TYPE_CHECKING:
+    from ._typing import Anchor, Package
+
+
+def __getattr__(name: str) -> object:
+    # Defer import to avoid an import-time dependency on typing, since Package and
+    # Anchor are type aliases that use symbols from typing.
+    if name in {"Anchor", "Package"}:
+        from . import _typing
+
+        obj = getattr(_typing, name)
+
+    else:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    globals()[name] = obj
+    return obj
+
+def __dir__() -> list[str]:
+    return sorted(globals().keys() | {"Anchor", "Package"})

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 
 
 def __getattr__(name: str) -> object:
-    # Defer import to avoid an import dependency on typing, since Package and Anchor
-    # are type aliases that use symbols from typing.
+    # Defer import to avoid an import-time dependency on typing, since Package and
+    # Anchor are type aliases that use symbols from typing.
     if name in {"Package", "Anchor"}:
         obj = getattr(_t, name)
     else:
@@ -30,6 +30,10 @@ def __getattr__(name: str) -> object:
 
     globals()[name] = obj
     return obj
+
+
+def __dir__() -> list[str]:
+    return sorted(globals().keys() | {"Package", "Anchor"})
 
 
 def package_to_anchor(func):

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -11,29 +11,6 @@ import warnings
 
 from . import _typing as _t
 from . import abc
-from ._typing import TYPE_CHECKING
-
-# Type checkers needs this block to understand what __getattr__() exports currently.
-if TYPE_CHECKING:
-    from ._typing import Anchor as Anchor
-    from ._typing import Package as Package
-
-
-def __getattr__(name: str) -> object:
-    # Defer import to avoid an import-time dependency on typing, since Package and
-    # Anchor are type aliases that use symbols from typing.
-    if name in {"Package", "Anchor"}:
-        obj = getattr(_t, name)
-    else:
-        msg = f"module {__name__!r} has no attribute {name!r}"
-        raise AttributeError(msg)
-
-    globals()[name] = obj
-    return obj
-
-
-def __dir__() -> list[str]:
-    return sorted(globals().keys() | {"Package", "Anchor"})
 
 
 def package_to_anchor(func):

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -8,9 +8,9 @@ import pathlib
 import tempfile
 import types
 import warnings
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
-from .abc import ResourceReader, Traversable
+from . import abc
 
 Package = Union[types.ModuleType, str]
 Anchor = Package
@@ -49,14 +49,14 @@ def package_to_anchor(func):
 
 
 @package_to_anchor
-def files(anchor: Optional[Anchor] = None) -> Traversable:
+def files(anchor: Optional[Anchor] = None) -> "abc.Traversable":
     """
     Get a Traversable resource for an anchor.
     """
     return from_package(resolve(anchor))
 
 
-def get_resource_reader(package: types.ModuleType) -> Optional[ResourceReader]:
+def get_resource_reader(package: types.ModuleType) -> Optional["abc.ResourceReader"]:
     """
     Return the package's loader if it's a ResourceReader.
     """
@@ -74,7 +74,7 @@ def get_resource_reader(package: types.ModuleType) -> Optional[ResourceReader]:
 
 @functools.singledispatch
 def resolve(cand: Optional[Anchor]) -> types.ModuleType:
-    return cast(types.ModuleType, cand)
+    return cand  # type: ignore[return-value] # Guarded by usage in from_package.
 
 
 @resolve.register
@@ -149,7 +149,7 @@ def _temp_file(path):
     return _tempfile(path.read_bytes, suffix=path.name)
 
 
-def _is_present_dir(path: Traversable) -> bool:
+def _is_present_dir(path: "abc.Traversable") -> bool:
     """
     Some Traversables implement ``is_dir()`` to raise an
     exception (i.e. ``FileNotFoundError``) when the

--- a/importlib_resources/_traversable.py
+++ b/importlib_resources/_traversable.py
@@ -1,0 +1,121 @@
+import abc
+import itertools
+import os
+import pathlib
+from collections.abc import Iterator
+from typing import (
+    Any,
+    BinaryIO,
+    Literal,
+    Optional,
+    Protocol,
+    TextIO,
+    Union,
+    overload,
+    runtime_checkable,
+)
+
+from .abc import TraversalError
+
+StrPath = Union[str, os.PathLike[str]]
+
+
+@runtime_checkable
+class Traversable(Protocol):
+    """
+    An object with a subset of pathlib.Path methods suitable for
+    traversing directories and opening files.
+
+    Any exceptions that occur when accessing the backing resource
+    may propagate unaltered.
+    """
+
+    @abc.abstractmethod
+    def iterdir(self) -> Iterator["Traversable"]:
+        """
+        Yield Traversable objects in self
+        """
+
+    def read_bytes(self) -> bytes:
+        """
+        Read contents of self as bytes
+        """
+        with self.open('rb') as strm:
+            return strm.read()
+
+    def read_text(
+        self, encoding: Optional[str] = None, errors: Optional[str] = None
+    ) -> str:
+        """
+        Read contents of self as text
+        """
+        with self.open(encoding=encoding, errors=errors) as strm:
+            return strm.read()
+
+    @abc.abstractmethod
+    def is_dir(self) -> bool:
+        """
+        Return True if self is a directory
+        """
+
+    @abc.abstractmethod
+    def is_file(self) -> bool:
+        """
+        Return True if self is a file
+        """
+
+    def joinpath(self, *descendants: StrPath) -> "Traversable":
+        """
+        Return Traversable resolved with any descendants applied.
+
+        Each descendant should be a path segment relative to self
+        and each may contain multiple levels separated by
+        ``posixpath.sep`` (``/``).
+        """
+        if not descendants:
+            return self
+        names = itertools.chain.from_iterable(
+            path.parts for path in map(pathlib.PurePosixPath, descendants)
+        )
+        target = next(names)
+        matches = (
+            traversable for traversable in self.iterdir() if traversable.name == target
+        )
+        try:
+            match = next(matches)
+        except StopIteration:
+            raise TraversalError(
+                "Target not found during traversal.", target, list(names)
+            )
+        return match.joinpath(*names)
+
+    def __truediv__(self, child: StrPath) -> "Traversable":
+        """
+        Return Traversable child in self
+        """
+        return self.joinpath(child)
+
+    @overload
+    def open(self, mode: Literal['r'] = 'r', *args: Any, **kwargs: Any) -> TextIO: ...
+
+    @overload
+    def open(self, mode: Literal['rb'], *args: Any, **kwargs: Any) -> BinaryIO: ...
+
+    @abc.abstractmethod
+    def open(
+        self, mode: str = 'r', *args: Any, **kwargs: Any
+    ) -> Union[TextIO, BinaryIO]:
+        """
+        mode may be 'r' or 'rb' to open as text or binary. Return a handle
+        suitable for reading (same as pathlib.Path.open).
+
+        When opening as text, accepts encoding parameters such as those
+        accepted by io.TextIOWrapper.
+        """
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """
+        The base name of this object without any parent references.
+        """

--- a/importlib_resources/_typing.py
+++ b/importlib_resources/_typing.py
@@ -39,6 +39,7 @@ __all__ = (
     # Other
     "Package",
     "Anchor",
+    "StrPath",
 
 )  # fmt: skip
 
@@ -48,6 +49,7 @@ TYPE_CHECKING = False
 
 # Type checkers needs this block to understand what __getattr__() does currently.
 if TYPE_CHECKING:
+    import os
     import types
     from collections.abc import Iterable, Iterator
     from typing import (
@@ -63,6 +65,7 @@ if TYPE_CHECKING:
 
     Package: TypeAlias = Union[types.ModuleType, str]
     Anchor = Package
+    StrPath: TypeAlias = Union[str, os.PathLike[str]]
 
 
 def __getattr__(name: str) -> object:
@@ -81,6 +84,12 @@ def __getattr__(name: str) -> object:
         from typing import Union
 
         obj = Union[types.ModuleType, str]
+
+    elif name == "StrPath":
+        import os
+        from typing import Union
+
+        obj = Union[str, "os.PathLike[str]"]
 
     else:
         msg = f"module {__name__!r} has no attribute {name!r}"

--- a/importlib_resources/_typing.py
+++ b/importlib_resources/_typing.py
@@ -47,7 +47,7 @@ __all__ = (
 TYPE_CHECKING = False
 
 
-# Type checkers needs this block to understand what __getattr__() does currently.
+# Type checkers needs this block to understand what __getattr__() exports currently.
 if TYPE_CHECKING:
     import os
     import types
@@ -89,7 +89,7 @@ def __getattr__(name: str) -> object:
         import os
         from typing import Union
 
-        obj = Union[str, "os.PathLike[str]"]
+        obj = Union[str, os.PathLike[str]]
 
     else:
         msg = f"module {__name__!r} has no attribute {name!r}"

--- a/importlib_resources/_typing.py
+++ b/importlib_resources/_typing.py
@@ -1,0 +1,94 @@
+"""Internal.
+
+A lazy re-export shim/middleman for typing-related symbols and annotation-related symbols to
+avoid import-time dependencies on expensive modules (like `typing`). Some symbols may
+eventually be needed at runtime, but their import/creation will be "on demand" to
+improve startup performance.
+
+Usage Notes
+-----------
+Do not directly import annotation-related symbols from this module
+(e.g. ``from ._lazy import Any``)! Doing so will trigger the module-level `__getattr__`,
+causing the modules of shimmed symbols, e.g. `typing`, to get imported. Instead, import
+the module and use symbols via attribute access as needed
+(e.g. ``from . import _lazy [as _t]``).
+
+Additionally, to avoid those symbols being evaluated at runtime, which would *also*
+cause shimmed modules to get imported, make sure to defer evaluation of annotations via
+the following:
+
+    a) <3.14: Manual stringification of annotations, or
+        `from __future__ import annotations`.
+    b) >=3.14: Nothing, thanks to default PEP 649 semantics.
+"""
+
+__all__ = (
+    # ---- Typing/annotation symbols ----
+    # collections.abc
+    "Iterable",
+    "Iterator",
+
+    # typing
+    "Any",
+    "BinaryIO",
+    "NoReturn",
+    "Optional",
+    "Text",
+    "Union",
+
+    # Other
+    "Package",
+    "Anchor",
+
+)  # fmt: skip
+
+
+TYPE_CHECKING = False
+
+
+# Type checkers needs this block to understand what __getattr__() does currently.
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterable, Iterator
+    from typing import (
+        Any,
+        BinaryIO,
+        NoReturn,
+        Optional,
+        Text,
+        Union,
+    )
+
+    from typing_extensions import TypeAlias
+
+    Package: TypeAlias = Union[types.ModuleType, str]
+    Anchor = Package
+
+
+def __getattr__(name: str) -> object:
+    if name in {"Iterable", "Iterator"}:
+        import collections.abc
+
+        obj = getattr(collections.abc, name)
+
+    elif name in {"Any", "BinaryIO", "NoReturn", "Text", "Optional", "Union"}:
+        import typing
+
+        obj = getattr(typing, name)
+
+    elif name in {"Package", "Anchor"}:
+        import types
+        from typing import Union
+
+        obj = Union[types.ModuleType, str]
+
+    else:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    globals()[name] = obj
+    return obj
+
+
+def __dir__() -> list[str]:
+    return sorted(globals().keys() | __all__)

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -87,7 +87,7 @@ class TraversableResources(ResourceReader):
     """
 
     @abc.abstractmethod
-    def files(self) -> "_self_mod.Traversable":
+    def files(self) -> _self_mod.Traversable:
         """Return a Traversable object for the loaded package."""
 
     def open_resource(self, resource: _t.StrPath) -> _t.BinaryIO:

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,26 +1,46 @@
 import abc
-import itertools
 import os
-import pathlib
 from typing import (
     Any,
     BinaryIO,
     Iterable,
     Iterator,
     NoReturn,
-    Literal,
-    Optional,
-    Protocol,
     Text,
-    TextIO,
     Union,
-    overload,
-    runtime_checkable,
 )
+
+from ._typing import TYPE_CHECKING
 
 StrPath = Union[str, os.PathLike[str]]
 
 __all__ = ["ResourceReader", "Traversable", "TraversableResources"]
+
+
+# A hack for the following targets:
+# a) Type checkers, so they can understand what __getattr__() exports.
+# b) Internal annotations, so that Traversable can be used in deferred annotations via
+#    _self_mod.Traversable.
+if TYPE_CHECKING:
+    from ._traversable import Traversable
+
+    class _self_mod:
+        from ._traversable import Traversable
+
+else:
+    _self_mod = __import__("sys").modules[__name__]
+
+
+def __getattr__(name: str) -> object:
+    # Defer import to avoid an import dependency on typing, since Traversable subclasses
+    # typing.Protocol.
+    if name == "Traversable":
+        from ._traversable import Traversable
+
+        return Traversable
+
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)
 
 
 class ResourceReader(metaclass=abc.ABCMeta):
@@ -69,107 +89,6 @@ class TraversalError(Exception):
     pass
 
 
-@runtime_checkable
-class Traversable(Protocol):
-    """
-    An object with a subset of pathlib.Path methods suitable for
-    traversing directories and opening files.
-
-    Any exceptions that occur when accessing the backing resource
-    may propagate unaltered.
-    """
-
-    @abc.abstractmethod
-    def iterdir(self) -> Iterator["Traversable"]:
-        """
-        Yield Traversable objects in self
-        """
-
-    def read_bytes(self) -> bytes:
-        """
-        Read contents of self as bytes
-        """
-        with self.open('rb') as strm:
-            return strm.read()
-
-    def read_text(
-        self, encoding: Optional[str] = None, errors: Optional[str] = None
-    ) -> str:
-        """
-        Read contents of self as text
-        """
-        with self.open(encoding=encoding, errors=errors) as strm:
-            return strm.read()
-
-    @abc.abstractmethod
-    def is_dir(self) -> bool:
-        """
-        Return True if self is a directory
-        """
-
-    @abc.abstractmethod
-    def is_file(self) -> bool:
-        """
-        Return True if self is a file
-        """
-
-    def joinpath(self, *descendants: StrPath) -> "Traversable":
-        """
-        Return Traversable resolved with any descendants applied.
-
-        Each descendant should be a path segment relative to self
-        and each may contain multiple levels separated by
-        ``posixpath.sep`` (``/``).
-        """
-        if not descendants:
-            return self
-        names = itertools.chain.from_iterable(
-            path.parts for path in map(pathlib.PurePosixPath, descendants)
-        )
-        target = next(names)
-        matches = (
-            traversable for traversable in self.iterdir() if traversable.name == target
-        )
-        try:
-            match = next(matches)
-        except StopIteration:
-            raise TraversalError(
-                "Target not found during traversal.", target, list(names)
-            )
-        return match.joinpath(*names)
-
-    def __truediv__(self, child: StrPath) -> "Traversable":
-        """
-        Return Traversable child in self
-        """
-        return self.joinpath(child)
-
-    @overload
-    def open(self, mode: Literal['r'] = 'r', *args: Any, **kwargs: Any) -> TextIO: ...
-
-    @overload
-    def open(self, mode: Literal['rb'], *args: Any, **kwargs: Any) -> BinaryIO: ...
-
-    @abc.abstractmethod
-    def open(
-        self, mode: str = 'r', *args: Any, **kwargs: Any
-    ) -> Union[TextIO, BinaryIO]:
-        """
-        mode may be 'r' or 'rb' to open as text or binary. Return a handle
-        suitable for reading (same as pathlib.Path.open).
-
-        When opening as text, accepts encoding parameters such as those
-        accepted by io.TextIOWrapper.
-        """
-
-    @property
-    @abc.abstractmethod
-    def name(self) -> str:
-        """
-        The base name of this object without any parent references.
-        """
-
-
 class TraversableResources(ResourceReader):
     """
     The required interface for providing traversable
@@ -177,7 +96,7 @@ class TraversableResources(ResourceReader):
     """
 
     @abc.abstractmethod
-    def files(self) -> "Traversable":
+    def files(self) -> "_self_mod.Traversable":
         """Return a Traversable object for the loaded package."""
 
     def open_resource(self, resource: StrPath) -> BinaryIO:

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -1,18 +1,9 @@
+from __future__ import annotations
+
 import abc
-import os
-from typing import (
-    Any,
-    BinaryIO,
-    Iterable,
-    Iterator,
-    NoReturn,
-    Text,
-    Union,
-)
 
+from . import _typing as _t
 from ._typing import TYPE_CHECKING
-
-StrPath = Union[str, os.PathLike[str]]
 
 __all__ = ["ResourceReader", "Traversable", "TraversableResources"]
 
@@ -47,7 +38,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
     """Abstract base class for loaders to provide resource reading support."""
 
     @abc.abstractmethod
-    def open_resource(self, resource: Text) -> BinaryIO:
+    def open_resource(self, resource: _t.Text) -> _t.BinaryIO:
         """Return an opened, file-like object for binary reading.
 
         The 'resource' argument is expected to represent only a file name.
@@ -59,7 +50,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
         raise FileNotFoundError
 
     @abc.abstractmethod
-    def resource_path(self, resource: Text) -> Text:
+    def resource_path(self, resource: _t.Text) -> _t.Text:
         """Return the file system path to the specified resource.
 
         The 'resource' argument is expected to represent only a file name.
@@ -72,7 +63,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
         raise FileNotFoundError
 
     @abc.abstractmethod
-    def is_resource(self, path: Text) -> bool:
+    def is_resource(self, path: _t.Text) -> bool:
         """Return True if the named 'path' is a resource.
 
         Files are resources, directories are not.
@@ -80,7 +71,7 @@ class ResourceReader(metaclass=abc.ABCMeta):
         raise FileNotFoundError
 
     @abc.abstractmethod
-    def contents(self) -> Iterable[str]:
+    def contents(self) -> _t.Iterable[str]:
         """Return an iterable of entries in `package`."""
         raise FileNotFoundError
 
@@ -99,14 +90,14 @@ class TraversableResources(ResourceReader):
     def files(self) -> "_self_mod.Traversable":
         """Return a Traversable object for the loaded package."""
 
-    def open_resource(self, resource: StrPath) -> BinaryIO:
+    def open_resource(self, resource: _t.StrPath) -> _t.BinaryIO:
         return self.files().joinpath(resource).open('rb')
 
-    def resource_path(self, resource: Any) -> NoReturn:
+    def resource_path(self, resource: _t.Any) -> _t.NoReturn:
         raise FileNotFoundError(resource)
 
-    def is_resource(self, path: StrPath) -> bool:
+    def is_resource(self, path: _t.StrPath) -> bool:
         return self.files().joinpath(path).is_file()
 
-    def contents(self) -> Iterator[str]:
+    def contents(self) -> _t.Iterator[str]:
         return (item.name for item in self.files().iterdir())

--- a/importlib_resources/abc.py
+++ b/importlib_resources/abc.py
@@ -23,15 +23,20 @@ else:
 
 
 def __getattr__(name: str) -> object:
-    # Defer import to avoid an import dependency on typing, since Traversable subclasses
-    # typing.Protocol.
+    # Defer import to avoid an import-time dependency on typing, since Traversable
+    # subclasses typing.Protocol.
     if name == "Traversable":
-        from ._traversable import Traversable
+        from ._traversable import Traversable as obj
+    else:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
 
-        return Traversable
+    globals()[name] = obj
+    return obj
 
-    msg = f"module {__name__!r} has no attribute {name!r}"
-    raise AttributeError(msg)
+
+def __dir__() -> list[str]:
+    return sorted(globals().keys() | {"Traversable"})
 
 
 class ResourceReader(metaclass=abc.ABCMeta):


### PR DESCRIPTION
Part of #326.

# Overview
`typing` as a import-time dependency can be avoided for most of this library's use cases through a combination of the following:

- Refactoring when possible to avoid using constructs that often import `typing`.
  - e.g. `functools.singledispatch`
- Isolation of components that unavoidably depend on `typing` at import time, so that importing them is opt-in.
  - e.g. `importlib_resources.abc.Traversable`
- Deferred annotations.
- Lazy imports via module-level `__getattr__`.

This way, when importing just the base or functional API (`files()`, `as_file()`, `open_binary`, etc.), which I imagine is a very common use case, users don't also import `typing` immediately as a side-effect. This will improve the import time of `importlib_resources` for such common cases by at least 10%, possibly more, while still having the type annotations be valid and resolve to the correct symbols when introspected/evaluated.

This PR's intended viewing is commit by commit, in order.

# Notes
I'm guessing this one will be a bit more controversial than the other PRs due to refactoring away usage of `functools.singledispatch`, but if we want to use `typing` without incurring its import cost on multiple Python versions, I think it's easiest to just avoid `singledispatch` altogether in `importlib_resources._common`. `singledispatch` usage is also a potential blocker for possible future improvements, e.g. lazily importing `pathlib.Path`.

That being said, I'll try to see if there's a way to use `singledispatch` for the moment without it unconditionally importing `typing`. Doing so would rely on implementation details and thus be fragile at best, so I'm not a fan of it.
