### PR TITLE
A better error message from importlib.resources.files() when module spec is None

### DIFF
--- a/importlib_resources/_adapters.py
+++ b/importlib_resources/_adapters.py
@@ -160,9 +160,9 @@ class CompatibilityFiles:
         return CompatibilityFiles.SpecPath(self.spec, self._reader)
 
 
-def wrap_spec(package):
+def wrap_spec(spec):
     """
     Construct a package spec with traversable compatibility
     on the spec/loader/reader.
     """
-    return SpecLoaderAdapter(package.__spec__, TraversableResourcesLoader)
+    return SpecLoaderAdapter(spec, TraversableResourcesLoader)

--- a/importlib_resources/_adapters.py
+++ b/importlib_resources/_adapters.py
@@ -160,9 +160,9 @@ class CompatibilityFiles:
         return CompatibilityFiles.SpecPath(self.spec, self._reader)
 
 
-def wrap_spec(spec):
+def wrap_spec(package):
     """
     Construct a package spec with traversable compatibility
     on the spec/loader/reader.
     """
-    return SpecLoaderAdapter(spec, TraversableResourcesLoader)
+    return SpecLoaderAdapter(package.__spec__, TraversableResourcesLoader)

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -105,6 +105,19 @@ def _infer_caller():
     return next(callers).frame
 
 
+def _assert_spec(package: types.ModuleType) -> None:
+    """
+    Provide a nicer error message when package is ``__main__``
+    and its ``__spec__`` is ``None``
+    (https://docs.python.org/3/reference/import.html#main-spec).
+    """
+    if package.__spec__ is None:
+        raise TypeError(
+            f"Cannot access resources for '{package.__name__}' "
+            "as it does not appear to correspond to an importable module (its __spec__ is None)."
+        )
+
+
 def from_package(package: types.ModuleType):
     """
     Return a Traversable object for the given package.
@@ -113,12 +126,7 @@ def from_package(package: types.ModuleType):
     # deferred for performance (python/cpython#109829)
     from .future.adapters import wrap_spec
 
-    if package.__spec__ is None:
-        raise TypeError(
-            f"Cannot access resources for '{package.__name__ or package!r}' "
-            "as it does not appear to correspond to an importable module (its __spec__ is None)."
-        )
-
+    _assert_spec(package)
     spec = wrap_spec(package)
     reader = spec.loader.get_resource_reader(spec.name)
     return reader.files()

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -113,7 +113,13 @@ def from_package(package: types.ModuleType):
     # deferred for performance (python/cpython#109829)
     from .future.adapters import wrap_spec
 
-    spec = wrap_spec(package)
+    if package.__spec__ is None:
+        raise TypeError(
+            f"Cannot access resources for '{package.__name__ or package!r}' "
+            "as it does not appear to correspond to an importable module (its __spec__ is None)."
+        )
+
+    spec = wrap_spec(package.__spec__)
     reader = spec.loader.get_resource_reader(spec.name)
     return reader.files()
 

--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -119,7 +119,7 @@ def from_package(package: types.ModuleType):
             "as it does not appear to correspond to an importable module (its __spec__ is None)."
         )
 
-    spec = wrap_spec(package.__spec__)
+    spec = wrap_spec(package)
     reader = spec.loader.get_resource_reader(spec.name)
     return reader.files()
 

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -1,3 +1,4 @@
+import types
 import unittest
 from importlib import import_module
 
@@ -232,6 +233,18 @@ class ResourceFromNamespaceZipTests(
     unittest.TestCase,
 ):
     MODULE = 'namespacedata01'
+
+
+class ResourceFromMainModuleWithNoneSpecTests(unittest.TestCase):
+    # `__main__.__spec__` can be `None` depending on how it is populated.
+    # https://docs.python.org/3/reference/import.html#main-spec
+    def test_main_module_with_none_spec(self):
+        mainmodule = types.ModuleType("__main__")
+
+        self.assertIsNone(mainmodule.__spec__)
+
+        with self.assertRaises(TypeError, msg="Cannot access resources for '__main__' as it does not appear to correspond to an importable module (its __spec__ is None)."):
+            resources.files(mainmodule)
 
 
 if __name__ == '__main__':

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -243,7 +243,10 @@ class ResourceFromMainModuleWithNoneSpecTests(unittest.TestCase):
 
         self.assertIsNone(mainmodule.__spec__)
 
-        with self.assertRaises(TypeError, msg="Cannot access resources for '__main__' as it does not appear to correspond to an importable module (its __spec__ is None)."):
+        with self.assertRaises(
+            TypeError,
+            msg="Cannot access resources for '__main__' as it does not appear to correspond to an importable module (its __spec__ is None).",
+        ):
             resources.files(mainmodule)
 
 

--- a/importlib_resources/tests/test_resource.py
+++ b/importlib_resources/tests/test_resource.py
@@ -220,13 +220,17 @@ class ResourceFromNamespaceZipTests(
     MODULE = 'namespacedata01'
 
 
-class ResourceFromMainModuleWithNoneSpecTests(unittest.TestCase):
-    # `__main__.__spec__` can be `None` depending on how it is populated.
-    # https://docs.python.org/3/reference/import.html#main-spec
+class MainModuleTests(unittest.TestCase):
     def test_main_module_with_none_spec(self):
+        """
+        __main__ module with no spec should raise TypeError (for clarity).
+
+        See python/cpython#138531 for details.
+        """
+        # construct a __main__ module with no __spec__.
         mainmodule = types.ModuleType("__main__")
 
-        self.assertIsNone(mainmodule.__spec__)
+        assert mainmodule.__spec__ is None
 
         with self.assertRaises(
             TypeError,

--- a/newsfragments/331.feature.rst
+++ b/newsfragments/331.feature.rst
@@ -1,0 +1,1 @@
+``files()`` now provides a nicer error when __main__.__spec__ is None.


### PR DESCRIPTION
Copied from a PR on the CPython repository's `importlib/resources`.
The original PR is https://github.com/python/cpython/pull/138531