### PR TITLE
gh-138044: Remove deprecated parameter alias for `importlib.resources.files` (python/cpython#138059)

### DIFF
--- a/importlib_resources/_common.py
+++ b/importlib_resources/_common.py
@@ -7,7 +7,6 @@ import os
 import pathlib
 import tempfile
 import types
-import warnings
 from typing import Optional, cast
 
 from .abc import ResourceReader, Traversable
@@ -16,39 +15,6 @@ Package = types.ModuleType | str
 Anchor = Package
 
 
-def package_to_anchor(func):
-    """
-    Replace 'package' parameter as 'anchor' and warn about the change.
-
-    Other errors should fall through.
-
-    >>> files('a', 'b')
-    Traceback (most recent call last):
-    TypeError: files() takes from 0 to 1 positional arguments but 2 were given
-
-    Remove this compatibility in Python 3.14.
-    """
-    undefined = object()
-
-    @functools.wraps(func)
-    def wrapper(anchor=undefined, package=undefined):
-        if package is not undefined:
-            if anchor is not undefined:
-                return func(anchor, package)
-            warnings.warn(
-                "First parameter to files is renamed to 'anchor'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return func(package)
-        elif anchor is undefined:
-            return func()
-        return func(anchor)
-
-    return wrapper
-
-
-@package_to_anchor
 def files(anchor: Optional[Anchor] = None) -> Traversable:
     """
     Get a Traversable resource for an anchor.

--- a/importlib_resources/tests/test_files.py
+++ b/importlib_resources/tests/test_files.py
@@ -39,14 +39,6 @@ class FilesTests:
         binfile = files.joinpath('subdirectory', 'binary.file')
         self.assertTrue(binfile.is_file())
 
-    def test_old_parameter(self):
-        """
-        Files used to take a 'package' parameter. Make sure anyone
-        passing by name is still supported.
-        """
-        with suppress_known_deprecation():
-            resources.files(package=self.data)
-
 
 class OpenDiskTests(FilesTests, util.DiskSetup, unittest.TestCase):
     pass

--- a/newsfragments/332.removal.rst
+++ b/newsfragments/332.removal.rst
@@ -1,0 +1,2 @@
+Remove compatibility shim for deprecated parameter *package* in
+:func:`importlib.resources.files`. Patch by Semyon Moroz.


### PR DESCRIPTION
Closes #332
